### PR TITLE
refactor: switch CI to Replicated CLI, rename release workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -175,7 +175,7 @@ jobs:
             oci://registry.replicated.com/${REPLICATED_APP}/${{ steps.release.outputs.channel }}/drone-rx \
             --version "${CHART_VERSION}" \
             --namespace default \
-            --wait --timeout 10m || true
+            --timeout 10m || true
 
       - name: Smoke test
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -167,9 +167,12 @@ jobs:
             --username "${EMAIL}" \
             --password "${LICENSE_ID}"
 
+          CHART_VERSION=$(grep '^version:' chart/Chart.yaml | awk '{print $2}')
+          echo "Chart version: ${CHART_VERSION}"
+
           helm install drone-rx \
             oci://registry.replicated.com/${REPLICATED_APP}/${{ steps.release.outputs.channel }}/drone-rx \
-            --version 0.0.0-${{ needs.build-and-push.outputs.tag }} \
+            --version "${CHART_VERSION}" \
             --namespace default \
             --wait --timeout 10m || true
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -152,7 +152,8 @@ jobs:
       - name: Get kubeconfig
         run: |
           replicated cluster kubeconfig \
-            --id "${{ steps.cluster.outputs.cluster-id }}" > kubeconfig.yaml
+            --id "${{ steps.cluster.outputs.cluster-id }}" \
+            --output-path kubeconfig.yaml
           export KUBECONFIG=./kubeconfig.yaml
           kubectl get nodes
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -152,7 +152,7 @@ jobs:
       - name: Get kubeconfig
         run: |
           replicated cluster kubeconfig \
-            --id "${{ steps.cluster.outputs.cluster-id }}" \
+            "${{ steps.cluster.outputs.cluster-id }}" \
             --output-path kubeconfig.yaml
           export KUBECONFIG=./kubeconfig.yaml
           kubectl get nodes
@@ -205,13 +205,13 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          replicated cluster rm --id "${{ steps.cluster.outputs.cluster-id }}" 2>/dev/null || true
+          replicated cluster rm "${{ steps.cluster.outputs.cluster-id }}" 2>/dev/null || true
 
       - name: Cleanup — archive customer
         if: always()
         continue-on-error: true
         run: |
-          replicated customer archive --id "${{ steps.customer.outputs.customer-id }}" 2>/dev/null || true
+          replicated customer archive "${{ steps.customer.outputs.customer-id }}" 2>/dev/null || true
 
       - name: Cleanup — archive channel
         if: always()

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -109,12 +109,13 @@ jobs:
           OUTPUT=$(replicated release create \
             --version 0.0.0-${{ needs.build-and-push.outputs.tag }} \
             --promote "${CHANNEL}" \
-            --ensure-channel \
-            --auto -y 2>&1)
+            --ensure-channel 2>&1)
           echo "${OUTPUT}"
           SEQUENCE=$(echo "${OUTPUT}" | grep -oE 'SEQUENCE:\s+[0-9]+' | grep -oE '[0-9]+')
+          CHANNEL_ID=$(echo "${OUTPUT}" | grep -oE 'Channel [a-zA-Z0-9]+' | head -1 | awk '{print $2}')
           echo "sequence=${SEQUENCE}" >> $GITHUB_OUTPUT
           echo "channel=${CHANNEL}" >> $GITHUB_OUTPUT
+          echo "channel-id=${CHANNEL_ID}" >> $GITHUB_OUTPUT
 
       - name: Create test customer
         id: customer
@@ -214,4 +215,4 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          replicated channel delete "${{ steps.release.outputs.channel }}" 2>/dev/null || true
+          replicated channel rm "${{ steps.release.outputs.channel-id }}" 2>/dev/null || true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -99,8 +99,9 @@ jobs:
       - name: Set image tags in chart values
         run: |
           TAG="${{ needs.build-and-push.outputs.tag }}"
-          sed -i "s|tag: \"latest\"|tag: \"${TAG}\"|g" chart/values.yaml
+          sed -i "s|tag: \"[^\"]*\" # x-release-please-version|tag: \"${TAG}\" # x-release-please-version|g" chart/values.yaml
           echo "Image tags set to: ${TAG}"
+          grep 'tag:' chart/values.yaml
 
       - name: Create release on temp channel
         id: release

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -77,8 +77,18 @@ jobs:
   test-on-cmx:
     runs-on: ubuntu-latest
     needs: build-and-push
+    env:
+      REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
+      REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install Replicated CLI
+        run: |
+          curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
+            | grep "browser_download_url.*linux_amd64.tar.gz" \
+            | cut -d '"' -f 4 \
+            | xargs curl -sL | tar xz -C /usr/local/bin replicated
 
       - name: Add Helm repos
         run: |
@@ -91,65 +101,77 @@ jobs:
           TAG="${{ needs.build-and-push.outputs.tag }}"
           sed -i "s|tag: \"latest\"|tag: \"${TAG}\"|g" chart/values.yaml
           echo "Image tags set to: ${TAG}"
-          grep 'tag:' chart/values.yaml
 
-      - name: Package Helm chart
+      - name: Create release on temp channel
+        id: release
         run: |
-          helm dependency build chart/
-          helm package chart/ -u
+          CHANNEL="pr-${{ github.event.pull_request.number }}-${GITHUB_RUN_ID}"
+          OUTPUT=$(replicated release create \
+            --version 0.0.0-${{ needs.build-and-push.outputs.tag }} \
+            --promote "${CHANNEL}" \
+            --ensure-channel \
+            --auto -y 2>&1)
+          echo "${OUTPUT}"
+          SEQUENCE=$(echo "${OUTPUT}" | grep -oE 'SEQUENCE:\s+[0-9]+' | grep -oE '[0-9]+')
+          echo "sequence=${SEQUENCE}" >> $GITHUB_OUTPUT
+          echo "channel=${CHANNEL}" >> $GITHUB_OUTPUT
 
-      - name: Define channel name
-        run: echo "CHANNEL_NAME=pr-${{ github.event.pull_request.number }}-${GITHUB_RUN_ID}" >> $GITHUB_ENV
-
-      - name: Create Release
-        id: create-release
-        uses: replicatedhq/replicated-actions/create-release@v1
-        with:
-          app-slug: ${{ secrets.REPLICATED_APP }}
-          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
-          chart: drone-rx-0.1.0.tgz
-          promote-channel: ${{ env.CHANNEL_NAME }}
-          version: 0.1.0
-
-      - name: Create Customer
-        id: create-customer
-        uses: replicatedhq/replicated-actions/create-customer@v1
-        with:
-          app-slug: ${{ secrets.REPLICATED_APP }}
-          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
-          customer-name: pr-${{ github.event.pull_request.number }}-test
-          channel-slug: ${{ steps.create-release.outputs.channel-slug }}
-          customer-email: pr-${{ github.event.pull_request.number }}@example.com
-          expires-in: 1
-          is-kots-install-enabled: "false"
-
-      - name: Create Cluster
-        id: create-cluster
-        uses: replicatedhq/replicated-actions/create-cluster@v1
-        with:
-          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
-          kubernetes-distribution: k3s
-          kubernetes-version: "1.34"
-          cluster-name: pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
-          ttl: 30m
-          timeout-minutes: 10
-
-      - name: Deploy with Helm
-        uses: replicatedhq/replicated-actions/helm-install@v1
-        with:
-          kubeconfig: ${{ steps.create-cluster.outputs.cluster-kubeconfig }}
-          helm-path: "helm"
-          registry-username: pr-${{ github.event.pull_request.number }}@example.com
-          registry-password: ${{ steps.create-customer.outputs.license-id }}
-          chart: oci://registry.replicated.com/${{ secrets.REPLICATED_APP }}/${{ steps.create-release.outputs.channel-slug }}/drone-rx
-          name: drone-rx
-          version: 0.1.0
-          namespace: default
-          run-preflights: "false"
-
-      - name: Smoke test — wait for pods
+      - name: Create test customer
+        id: customer
         run: |
-          echo "${{ steps.create-cluster.outputs.cluster-kubeconfig }}" > kubeconfig.yaml
+          OUTPUT=$(replicated customer create \
+            --name "pr-${{ github.event.pull_request.number }}-test" \
+            --channel "${{ steps.release.outputs.channel }}" \
+            --expires-in 24h \
+            --kots-install=false \
+            --helm-install \
+            --ensure-channel \
+            --output json 2>&1)
+          echo "${OUTPUT}"
+          CUSTOMER_ID=$(echo "${OUTPUT}" | jq -r '.id')
+          LICENSE_ID=$(echo "${OUTPUT}" | jq -r '.installationId')
+          echo "customer-id=${CUSTOMER_ID}" >> $GITHUB_OUTPUT
+          echo "license-id=${LICENSE_ID}" >> $GITHUB_OUTPUT
+
+      - name: Create CMX cluster
+        id: cluster
+        run: |
+          OUTPUT=$(replicated cluster create \
+            --distribution k3s \
+            --version 1.34 \
+            --name "pr-${{ github.event.pull_request.number }}-${GITHUB_RUN_ID}" \
+            --ttl 30m \
+            --wait 10m \
+            --output json 2>&1)
+          echo "${OUTPUT}"
+          CLUSTER_ID=$(echo "${OUTPUT}" | jq -r '.id')
+          echo "cluster-id=${CLUSTER_ID}" >> $GITHUB_OUTPUT
+
+      - name: Get kubeconfig
+        run: |
+          replicated cluster kubeconfig \
+            --id "${{ steps.cluster.outputs.cluster-id }}" > kubeconfig.yaml
+          export KUBECONFIG=./kubeconfig.yaml
+          kubectl get nodes
+
+      - name: Helm install from Replicated registry
+        run: |
+          export KUBECONFIG=./kubeconfig.yaml
+          EMAIL="pr-${{ github.event.pull_request.number }}@example.com"
+          LICENSE_ID="${{ steps.customer.outputs.license-id }}"
+
+          helm registry login registry.replicated.com \
+            --username "${EMAIL}" \
+            --password "${LICENSE_ID}"
+
+          helm install drone-rx \
+            oci://registry.replicated.com/${REPLICATED_APP}/${{ steps.release.outputs.channel }}/drone-rx \
+            --version 0.0.0-${{ needs.build-and-push.outputs.tag }} \
+            --namespace default \
+            --wait --timeout 10m || true
+
+      - name: Smoke test
+        run: |
           export KUBECONFIG=./kubeconfig.yaml
 
           echo "Waiting for pods to schedule..."
@@ -167,12 +189,7 @@ jobs:
           echo "Waiting for API..."
           kubectl rollout status deployment -l app.kubernetes.io/component=api -n default --timeout=300s || true
 
-          echo "Pod status:"
           kubectl get pods -n default
-
-      - name: Smoke test — health check
-        run: |
-          export KUBECONFIG=./kubeconfig.yaml
 
           API_SVC=$(kubectl get svc -n default -l app.kubernetes.io/component=api -o jsonpath='{.items[0].metadata.name}')
           echo "Found API service: ${API_SVC}"
@@ -181,27 +198,20 @@ jobs:
           curl -f http://localhost:8080/healthz
           echo "Health check passed"
 
-      - name: Remove Cluster
+      - name: Cleanup — remove cluster
         if: always()
-        uses: replicatedhq/replicated-actions/remove-cluster@v1
         continue-on-error: true
-        with:
-          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
-          cluster-id: ${{ steps.create-cluster.outputs.cluster-id }}
+        run: |
+          replicated cluster rm --id "${{ steps.cluster.outputs.cluster-id }}" 2>/dev/null || true
 
-      - name: Archive Customer
+      - name: Cleanup — archive customer
         if: always()
-        uses: replicatedhq/replicated-actions/archive-customer@v1
         continue-on-error: true
-        with:
-          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
-          customer-id: ${{ steps.create-customer.outputs.customer-id }}
+        run: |
+          replicated customer archive --id "${{ steps.customer.outputs.customer-id }}" 2>/dev/null || true
 
-      - name: Archive Channel
+      - name: Cleanup — archive channel
         if: always()
-        uses: replicatedhq/replicated-actions/archive-channel@v1
         continue-on-error: true
-        with:
-          app-slug: ${{ secrets.REPLICATED_APP }}
-          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
-          channel-slug: ${{ steps.create-release.outputs.channel-slug }}
+        run: |
+          replicated channel delete "${{ steps.release.outputs.channel }}" 2>/dev/null || true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -122,6 +122,7 @@ jobs:
         run: |
           OUTPUT=$(replicated customer create \
             --name "pr-${{ github.event.pull_request.number }}-test" \
+            --email "pr-${{ github.event.pull_request.number }}@example.com" \
             --channel "${{ steps.release.outputs.channel }}" \
             --expires-in 24h \
             --kots-install=false \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Set image tags and chart version
         run: |
           VERSION="${{ needs.build-and-push.outputs.version }}"
-          sed -i "s|tag: \"latest\"|tag: \"${VERSION}\"|g" chart/values.yaml
+          sed -i "s|tag: \"[^\"]*\" # x-release-please-version|tag: \"${VERSION}\" # x-release-please-version|g" chart/values.yaml
           sed -i "s|^version:.*|version: ${VERSION}|" chart/Chart.yaml
           sed -i "s|^appVersion:.*|appVersion: \"${VERSION}\"|" chart/Chart.yaml
           sed -i "s/\$VERSION/${VERSION}/g" replicated/dronerx-chart.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -205,7 +205,7 @@ jobs:
             oci://registry.replicated.com/${REPLICATED_APP}/unstable/drone-rx \
             --version ${{ needs.build-and-push.outputs.version }} \
             --namespace default \
-            --wait --timeout 10m || true
+            --timeout 10m || true
 
       - name: Smoke test
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -157,6 +157,7 @@ jobs:
         run: |
           OUTPUT=$(replicated customer create \
             --name "release-${{ github.run_id }}-test" \
+            --email "release-${{ github.run_id }}@example.com" \
             --channel Unstable \
             --expires-in 24h \
             --kots-install=false \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -186,7 +186,7 @@ jobs:
       - name: Get kubeconfig
         run: |
           replicated cluster kubeconfig \
-            --id "${{ steps.cluster.outputs.cluster-id }}" \
+            "${{ steps.cluster.outputs.cluster-id }}" \
             --output-path kubeconfig.yaml
           export KUBECONFIG=./kubeconfig.yaml
           kubectl get nodes
@@ -236,10 +236,10 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          replicated cluster rm --id "${{ steps.cluster.outputs.cluster-id }}" 2>/dev/null || true
+          replicated cluster rm "${{ steps.cluster.outputs.cluster-id }}" 2>/dev/null || true
 
       - name: Cleanup — archive customer
         if: always()
         continue-on-error: true
         run: |
-          replicated customer archive --id "${{ steps.customer.outputs.customer-id }}" 2>/dev/null || true
+          replicated customer archive "${{ steps.customer.outputs.customer-id }}" 2>/dev/null || true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -186,7 +186,8 @@ jobs:
       - name: Get kubeconfig
         run: |
           replicated cluster kubeconfig \
-            --id "${{ steps.cluster.outputs.cluster-id }}" > kubeconfig.yaml
+            --id "${{ steps.cluster.outputs.cluster-id }}" \
+            --output-path kubeconfig.yaml
           export KUBECONFIG=./kubeconfig.yaml
           kubectl get nodes
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: Replicated Release
 
 on:
   push:
@@ -85,10 +85,19 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     outputs:
-      release-sequence: ${{ steps.release.outputs.release-sequence }}
-      channel-slug: ${{ steps.release.outputs.channel-slug }}
+      release-sequence: ${{ steps.release.outputs.sequence }}
+    env:
+      REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
+      REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install Replicated CLI
+        run: |
+          curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
+            | grep "browser_download_url.*linux_amd64.tar.gz" \
+            | cut -d '"' -f 4 \
+            | xargs curl -sL | tar xz -C /usr/local/bin replicated
 
       - name: Add Helm repos
         run: |
@@ -96,90 +105,109 @@ jobs:
           helm repo add nats https://nats-io.github.io/k8s/helm/charts
           helm repo update
 
-      - name: Set image tags in chart values
+      - name: Set image tags and chart version
         run: |
           VERSION="${{ needs.build-and-push.outputs.version }}"
           sed -i "s|tag: \"latest\"|tag: \"${VERSION}\"|g" chart/values.yaml
-
-      - name: Update version in Chart.yaml
-        run: |
-          VERSION="${{ needs.build-and-push.outputs.version }}"
           sed -i "s|^version:.*|version: ${VERSION}|" chart/Chart.yaml
           sed -i "s|^appVersion:.*|appVersion: \"${VERSION}\"|" chart/Chart.yaml
-
-      - name: Update version in HelmChart CR
-        run: |
-          sed -i "s/\$VERSION/${{ needs.build-and-push.outputs.version }}/g" replicated/dronerx-chart.yaml
-
-      - name: Package Helm chart into release directory
-        run: |
-          helm dependency build chart/
-          helm package chart/ \
-            --version ${{ needs.build-and-push.outputs.version }} \
-            --app-version ${{ needs.build-and-push.outputs.version }} \
-            -d replicated/
+          sed -i "s/\$VERSION/${VERSION}/g" replicated/dronerx-chart.yaml
 
       - name: Create Replicated Release and Promote to Unstable
         id: release
-        uses: replicatedhq/replicated-actions/create-release@v1
-        with:
-          app-slug: ${{ secrets.REPLICATED_APP }}
-          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
-          yaml-dir: ./replicated
-          promote-channel: Unstable
-          version: ${{ needs.build-and-push.outputs.version }}
+        run: |
+          OUTPUT=$(replicated release create \
+            --version ${{ needs.build-and-push.outputs.version }} \
+            --promote Unstable \
+            --ensure-channel \
+            --auto -y 2>&1)
+          echo "${OUTPUT}"
+          SEQUENCE=$(echo "${OUTPUT}" | grep -oE 'SEQUENCE:\s+[0-9]+' | grep -oE '[0-9]+')
+          echo "sequence=${SEQUENCE}" >> $GITHUB_OUTPUT
 
       - name: Upload Helm chart to GitHub Release
+        run: |
+          VERSION="${{ needs.build-and-push.outputs.version }}"
+          helm dependency build chart/
+          helm package chart/ --version ${VERSION} --app-version ${VERSION}
+
+      - name: Attach chart to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            replicated/drone-rx-${{ needs.build-and-push.outputs.version }}.tgz
+            drone-rx-${{ needs.build-and-push.outputs.version }}.tgz
 
   test-on-cmx:
     runs-on: ubuntu-latest
     needs: [build-and-push, create-release]
+    env:
+      REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
+      REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create Customer
-        id: create-customer
-        uses: replicatedhq/replicated-actions/create-customer@v1
-        with:
-          app-slug: ${{ secrets.REPLICATED_APP }}
-          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
-          customer-name: release-${{ github.run_id }}-test
-          channel-slug: ${{ needs.create-release.outputs.channel-slug }}
-          customer-email: release-${{ github.run_id }}@example.com
-          expires-in: 1
-          is-kots-install-enabled: "false"
+      - name: Install Replicated CLI
+        run: |
+          curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
+            | grep "browser_download_url.*linux_amd64.tar.gz" \
+            | cut -d '"' -f 4 \
+            | xargs curl -sL | tar xz -C /usr/local/bin replicated
 
-      - name: Create Cluster
-        id: create-cluster
-        uses: replicatedhq/replicated-actions/create-cluster@v1
-        with:
-          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
-          kubernetes-distribution: k3s
-          kubernetes-version: "1.34"
-          cluster-name: release-${{ github.run_id }}
-          ttl: 20m
-          timeout-minutes: 10
+      - name: Create test customer
+        id: customer
+        run: |
+          OUTPUT=$(replicated customer create \
+            --name "release-${{ github.run_id }}-test" \
+            --channel Unstable \
+            --expires-in 24h \
+            --kots-install=false \
+            --helm-install \
+            --output json 2>&1)
+          echo "${OUTPUT}"
+          CUSTOMER_ID=$(echo "${OUTPUT}" | jq -r '.id')
+          LICENSE_ID=$(echo "${OUTPUT}" | jq -r '.installationId')
+          echo "customer-id=${CUSTOMER_ID}" >> $GITHUB_OUTPUT
+          echo "license-id=${LICENSE_ID}" >> $GITHUB_OUTPUT
 
-      - name: Deploy with Helm
-        uses: replicatedhq/replicated-actions/helm-install@v1
-        with:
-          kubeconfig: ${{ steps.create-cluster.outputs.cluster-kubeconfig }}
-          helm-path: "helm"
-          registry-username: release-${{ github.run_id }}@example.com
-          registry-password: ${{ steps.create-customer.outputs.license-id }}
-          chart: oci://registry.replicated.com/${{ secrets.REPLICATED_APP }}/${{ needs.create-release.outputs.channel-slug }}/drone-rx
-          name: drone-rx
-          version: ${{ needs.build-and-push.outputs.version }}
-          namespace: default
-          run-preflights: "false"
+      - name: Create CMX cluster
+        id: cluster
+        run: |
+          OUTPUT=$(replicated cluster create \
+            --distribution k3s \
+            --version 1.34 \
+            --name "release-${GITHUB_RUN_ID}" \
+            --ttl 20m \
+            --wait 10m \
+            --output json 2>&1)
+          echo "${OUTPUT}"
+          CLUSTER_ID=$(echo "${OUTPUT}" | jq -r '.id')
+          echo "cluster-id=${CLUSTER_ID}" >> $GITHUB_OUTPUT
+
+      - name: Get kubeconfig
+        run: |
+          replicated cluster kubeconfig \
+            --id "${{ steps.cluster.outputs.cluster-id }}" > kubeconfig.yaml
+          export KUBECONFIG=./kubeconfig.yaml
+          kubectl get nodes
+
+      - name: Helm install from Replicated registry
+        run: |
+          export KUBECONFIG=./kubeconfig.yaml
+          EMAIL="release-${GITHUB_RUN_ID}@example.com"
+          LICENSE_ID="${{ steps.customer.outputs.license-id }}"
+
+          helm registry login registry.replicated.com \
+            --username "${EMAIL}" \
+            --password "${LICENSE_ID}"
+
+          helm install drone-rx \
+            oci://registry.replicated.com/${REPLICATED_APP}/unstable/drone-rx \
+            --version ${{ needs.build-and-push.outputs.version }} \
+            --namespace default \
+            --wait --timeout 10m || true
 
       - name: Smoke test
         run: |
-          echo "${{ steps.create-cluster.outputs.cluster-kubeconfig }}" > kubeconfig.yaml
           export KUBECONFIG=./kubeconfig.yaml
 
           echo "Waiting for pods to schedule..."
@@ -203,18 +231,14 @@ jobs:
           curl -f http://localhost:8080/healthz
           echo "Health check passed"
 
-      - name: Remove Cluster
+      - name: Cleanup — remove cluster
         if: always()
-        uses: replicatedhq/replicated-actions/remove-cluster@v1
         continue-on-error: true
-        with:
-          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
-          cluster-id: ${{ steps.create-cluster.outputs.cluster-id }}
+        run: |
+          replicated cluster rm --id "${{ steps.cluster.outputs.cluster-id }}" 2>/dev/null || true
 
-      - name: Archive Customer
+      - name: Cleanup — archive customer
         if: always()
-        uses: replicatedhq/replicated-actions/archive-customer@v1
         continue-on-error: true
-        with:
-          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
-          customer-id: ${{ steps.create-customer.outputs.customer-id }}
+        run: |
+          replicated customer archive --id "${{ steps.customer.outputs.customer-id }}" 2>/dev/null || true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,8 +119,7 @@ jobs:
           OUTPUT=$(replicated release create \
             --version ${{ needs.build-and-push.outputs.version }} \
             --promote Unstable \
-            --ensure-channel \
-            --auto -y 2>&1)
+            --ensure-channel 2>&1)
           echo "${OUTPUT}"
           SEQUENCE=$(echo "${OUTPUT}" | grep -oE 'SEQUENCE:\s+[0-9]+' | grep -oE '[0-9]+')
           echo "sequence=${SEQUENCE}" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ chart/charts/
 
 # Build artifacts
 api
+*.tgz
 
 # Kubeconfig
 *.kubeconfig

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: drone-rx
 description: Medicine delivery by drone
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 1.0.0 # x-release-please-version
+appVersion: "1.0.0" # x-release-please-version
 
 dependencies:
   - name: cloudnative-pg

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -67,7 +67,7 @@ externalDatabase:
 imagePullSecrets: []
 
 replicated:
-  nameOverride:: "drone-rx-sdk"
+  nameOverride: "drone-rx-sdk"
   image:
     registry: images.littleroom.co.nz
     repository: library/replicated-sdk-image

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,7 +1,7 @@
 api:
   image:
     repository: images.littleroom.co.nz/proxy/drone-rx/ghcr.io/jmboby/dronerx-api
-    tag: "latest"
+    tag: "1.0.0" # x-release-please-version
     pullPolicy: IfNotPresent
   replicas: 1
   port: 8080
@@ -18,7 +18,7 @@ api:
 frontend:
   image:
     repository: images.littleroom.co.nz/proxy/drone-rx/ghcr.io/jmboby/dronerx-frontend
-    tag: "latest"
+    tag: "1.0.0" # x-release-please-version
     pullPolicy: IfNotPresent
   replicas: 1
   port: 3000

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -67,7 +67,7 @@ externalDatabase:
 imagePullSecrets: []
 
 replicated:
-  fullnameOverride: "drone-rx-sdk"
+  nameOverride:: "drone-rx-sdk"
   image:
     registry: images.littleroom.co.nz
     repository: library/replicated-sdk-image

--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -1,0 +1,142 @@
+# DroneRx Friction Log
+
+Pain points encountered while building and distributing a Helm-based app with Replicated.
+
+---
+
+## Tier 0 — Build It
+
+### CloudNativePG CRD chicken-and-egg
+**Problem:** Including CNPG operator as a subchart and creating a Cluster CR in the same Helm release fails because Helm validates all manifests before applying any — CRDs don't exist yet.
+**Error:** `no matches for kind "Cluster" in version "postgresql.cnpg.io/v1"`
+**Resolution:** Made the Cluster CR a `post-install` hook so it's applied after the operator subchart registers CRDs.
+**Time spent:** ~30 minutes figuring out the right approach.
+
+### CNPG operator webhook timing
+**Problem:** Even with the CR as a post-install hook, the operator webhook isn't ready when Helm fires the hook. The operator pod needs time to start and register endpoints.
+**Error:** `failed calling webhook "mcluster.cnpg.io": no endpoints available for service "cnpg-webhook-service"`
+**Resolution:** Added a wait Job (busybox + `nc -z`) as a post-install hook at weight 1, before the Cluster CR hook at weight 10. Polls the webhook service port until ready.
+**Time spent:** Multiple iterations — tried kubectl wait (needed RBAC), then simplified to nc.
+
+### Go status enum mismatch with Postgres
+**Problem:** Go constant `StatusInFlight = "in_flight"` (underscore) didn't match Postgres enum `'in-flight'` (hyphen). Orders advanced from `placed` to `preparing` but never to `in-flight`.
+**Error:** Silent failure — ticker logged errors but orders stayed stuck at `preparing`.
+**Resolution:** Changed Go constant to match DB: `StatusInFlight = "in-flight"`.
+**Time spent:** ~10 minutes — user noticed orders weren't progressing and reported it.
+
+### Docker amd64 builds for CMX
+**Problem:** Building Docker images on Apple Silicon (arm64) and pushing to GHCR, then pulling on CMX k3s clusters (amd64) fails with platform mismatch.
+**Error:** `no match for platform in manifest: not found`
+**Resolution:** `docker build --platform linux/amd64` for all CI builds.
+**Lesson:** Always build for the target platform, not the dev machine.
+
+---
+
+## Tier 1 — Automate It
+
+### GHCR package permissions for GitHub Actions
+**Problem:** `GITHUB_TOKEN` in workflows can't push to GHCR packages that were originally created by manual `docker push`.
+**Error:** `denied: permission_denied: write_package`
+**Resolution:** Two steps: (1) Enable "Read and write permissions" in repo Settings → Actions → Workflow permissions. (2) Link existing GHCR packages to the repo in Package Settings → Repository Access.
+**Time spent:** ~20 minutes across two separate permission issues.
+
+### prepare-cluster vs create-cluster
+**Problem:** Started with `replicatedhq/replicated-actions/prepare-cluster` (all-in-one action). It doesn't properly handle image pull auth for `proxy.replicated.com` — creates auth for `registry.replicated.com` (OCI chart pull) but not for the proxy registry used by pod image pulls.
+**Error:** `failed to authorize: failed to fetch anonymous token` on all proxied images.
+**Resolution:** Switched to individual CLI commands: `replicated release create` → `replicated customer create` → `replicated cluster create` → `helm install`. The `helm-install` step with registry credentials handles auth correctly.
+**Time spent:** ~2 hours across multiple debugging iterations.
+**Lesson:** Use the `replicated` CLI, not `replicated-actions`. The CLI also supports Embedded Cluster which actions don't.
+
+### replicated-actions vs CLI
+**Problem:** After switching to CLI, used `--auto -y` flag which ignores the `.replicated` config file and defaults to looking for `./manifests` directory.
+**Error:** `lstat ./manifests: no such file or directory`
+**Resolution:** Remove `--auto -y` — the CLI reads `.replicated` automatically without it.
+**Time spent:** ~15 minutes — was able to test locally with the CLI to reproduce.
+
+### RBAC policy resource names are lowercase
+**Problem:** The Vendor Portal documentation shows resource names in mixed case (e.g., `KOTS/app/*/read`) but the actual policy format requires lowercase.
+**Error:** Various 403 errors on release creation, customer creation, cluster operations.
+**Resolution:** Used `kots/` prefix (lowercase), not `KOTS/`. Also discovered that `kots/cluster/*/kubeconfig` is a separate permission from `kots/cluster/*`.
+**Time spent:** ~45 minutes across multiple RBAC iterations.
+**Lesson:** Start with broad permissions (`**/*` minus `team/**`), get CI working, then tighten.
+
+### Channel slugs must be lowercase
+**Problem:** Promote workflow used `Stable` (capitalized) but the API expects lowercase slugs.
+**Error:** `Could not find channel with slug Stable or name undefined`
+**Resolution:** Changed to `stable` in the workflow.
+**Time spent:** 5 minutes.
+
+### Helm-only release vs KOTS customer
+**Problem:** `create-customer` defaults to KOTS install enabled. Our release is Helm-only, so assigning a KOTS customer to a Helm-only channel fails.
+**Error:** `Cannot assign customer with KOTS install enabled to a channel with a helm-cli-only release`
+**Resolution:** Add `--kots-install=false --helm-install` to customer create.
+**Time spent:** 5 minutes once the error was clear.
+
+### Version label must match chart version
+**Problem:** `create-release` with `chart:` input requires the `version` label to match the version inside the packaged `.tgz`. We were using dynamic versions (`0.1.0-pr-9-sha`) but the chart was packaged as `0.1.0`.
+**Error:** `Version label does not match any Helm charts in the release`
+**Resolution:** Use the chart's native version from `Chart.yaml` for the release, bake dynamic tags into `values.yaml` via `sed` before packaging.
+**Time spent:** ~15 minutes.
+
+### `channel rm` needs ID not name
+**Problem:** `replicated channel delete <name>` doesn't work — the CLI requires the channel ID.
+**Error:** `archive app channel: Not found`
+**Resolution:** Capture channel ID from the release create output and use `replicated channel rm <ID>`.
+**Time spent:** 5 minutes.
+
+### GitHub Actions default branch
+**Problem:** The repo was created with `feat/phase1-build-it` as the default branch (from the initial push). The `promote.yaml` workflow with `workflow_dispatch` wasn't visible in the Actions UI because GitHub looks for workflows on the default branch.
+**Error:** `workflow promote.yaml not found on the default branch`
+**Resolution:** Changed default branch to `main` in repo Settings.
+**Time spent:** 10 minutes.
+
+---
+
+## Tier 2 — Ship It with Helm
+
+### Image proxy path format
+**Problem:** Multiple iterations getting the proxy image path format right. Started with `proxy.replicated.com/proxy/app/docker.io/library/busybox`, then `proxy.replicated.com/proxy/app/library/busybox`, then `/anonymous/index.docker.io/library/busybox`.
+**Error:** Various 400/404/401 errors on image pulls.
+**Resolution:** The correct approach is to add all registries (including Docker Hub) as external registries in the Vendor Portal, then use `/proxy/<app-slug>/` for everything. Each registry needs credentials configured even for public images.
+**Time spent:** ~2 hours across many iterations.
+**Lesson:** Don't use `/anonymous/` path — add registries properly in Vendor Portal.
+
+### imagePullSecrets needed everywhere
+**Problem:** Added `imagePullSecrets` to deployments but forgot about hook Jobs (wait-for-cnpg, self-signed cert). These also need the `enterprise-pull-secret` to pull images through the proxy.
+**Error:** `ErrImagePull` on hook job pods.
+**Resolution:** Added `imagePullSecrets` helper include to ALL pod specs — deployments AND jobs.
+**Time spent:** 15 minutes.
+
+### NATS global.image.registry inconsistency
+**Problem:** Set `global.image.registry` in NATS subchart values expecting it to apply to all images. The main `nats` container still used the default `nats:2.12.6-alpine` without the registry prefix.
+**Error:** `pull access denied, repository does not exist`
+**Resolution:** Use per-image `registry` overrides instead of `global.image.registry` — set `registry` on each of `nats`, `reloader`, and `natsBox` individually.
+**Time spent:** 20 minutes.
+
+### SDK metrics silently failing
+**Problem:** Custom metrics weren't appearing in Vendor Portal. The `SendMetrics` function silently returned nil on all errors — no logging, no visibility.
+**Resolution:** Added error logging to `SendMetrics`. Also added immediate send on startup (not just after first 5-minute interval) for faster verification.
+**Lesson:** Never silently swallow errors in best-effort code. Log them.
+
+### Stale releases on Unstable channel
+**Problem:** Multiple commits pushed to main, some release workflows failed partway through. A failed workflow still created and promoted a release (with broken image paths) to Unstable. The later fix commit's release was overshadowed.
+**Resolution:** Pushed an empty commit to trigger a fresh release from the correct state.
+**Lesson:** Failed release workflows can leave stale releases on channels. Check what's actually on the channel, not just what CI reports.
+
+---
+
+## General Observations
+
+### What worked well
+- The `.replicated` config file for release packaging — simple, declarative
+- release-please for semver management — clean flow with Release PRs
+- CloudNativePG as a subchart — once the webhook timing was solved, very clean
+- CMX k3s clusters for CI testing — fast provisioning, realistic environment
+- Replicated SDK for license gating — runtime queries with no-redeploy updates
+
+### What could be improved
+- **Documentation inconsistency** — RBAC resource names shown in mixed case in docs but require lowercase in config
+- **prepare-cluster action** — doesn't handle image proxy auth, should probably be deprecated in favour of CLI
+- **Proxy registry auth** — not obvious that `registry.replicated.com` (OCI chart pull) and `proxy.replicated.com` (image proxy) are different auth domains
+- **Error messages** — many Replicated API errors are generic (403, 400) without indicating which specific permission is missing
+- **CLI `--auto` flag** — confusing that it ignores `.replicated` config rather than enhancing it

--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -60,6 +60,12 @@ Pain points encountered while building and distributing a Helm-based app with Re
 **Time spent:** ~45 minutes across multiple RBAC iterations.
 **Lesson:** Start with broad permissions (`**/*` minus `team/**`), get CI working, then tighten.
 
+### Helm-install customer requires email
+**Problem:** `replicated customer create --helm-install` requires `--email` but this isn't obvious from the help text. The error only appears at runtime.
+**Error:** `email is required for customers with helm install enabled`
+**Resolution:** Add `--email "name@example.com"` to customer create.
+**Lesson:** Test CLI commands locally before embedding in CI workflows.
+
 ### Channel slugs must be lowercase
 **Problem:** Promote workflow used `Stable` (capitalized) but the API expects lowercase slugs.
 **Error:** `Could not find channel with slug Stable or name undefined`

--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -4,6 +4,17 @@ Pain points encountered while building and distributing a Helm-based app with Re
 
 ---
 
+## Process — AI Agent Workflow
+
+### Claude was too confident writing CI code from docs alone
+**Problem:** Claude read Replicated CLI docs and `--help` output, then immediately wrote commands into GitHub Actions workflows without testing them locally first. Multiple commands had hidden requirements not obvious from docs (e.g., `--email` required with `--helm-install`, `--auto -y` ignoring `.replicated` config, `--id` deprecated in favour of positional args, stdout warnings corrupting kubeconfig redirects).
+**Impact:** Each failure required waiting 5-10 minutes for a GH Actions run + CMX cluster to spin up, only to discover a simple flag issue. This happened repeatedly across multiple CI iterations.
+**Resolution:** Established a rule: always run `replicated` CLI commands locally using the API token before embedding them in workflows. Use existing CMX clusters for testing (`replicated cluster ls`) instead of creating new ones.
+**Time wasted:** ~2-3 hours across all CI iterations that could have been caught in seconds locally.
+**Lesson:** Don't trust docs or help output alone. Run the actual command first, verify the output format, then write the workflow. This applies to any CLI tool being embedded in CI.
+
+---
+
 ## Tier 0 — Build It
 
 ### CloudNativePG CRD chicken-and-egg

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [
-        "chart/Chart.yaml"
+        "chart/Chart.yaml",
+        "chart/values.yaml"
       ]
     }
   }


### PR DESCRIPTION
## Summary

### Workflow changes
- **PR workflow** — all replicated-actions replaced with `replicated` CLI commands
- **Replicated Release** (renamed from "Release") — triggers on `v*.*.*` tags, uses CLI
- Both workflows now use: `replicated release create`, `replicated customer create`, `replicated cluster create`, `replicated cluster kubeconfig`, `helm install` directly

### Why CLI over actions
- Actions don't support Embedded Cluster (needed for Tier 4)
- CLI gives more control over output parsing and error handling
- Single dependency (CLI binary) instead of multiple action versions

### Also fixes
- NATS images: per-image registry overrides instead of global (fixes nats pull error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)