### PR TITLE
feat: chain release-please to Replicated Release via workflow_call

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   release-please:
@@ -21,3 +22,9 @@ jobs:
         with:
           release-type: simple
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  replicated-release:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/release.yaml
+    secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_call:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Tags created by `GITHUB_TOKEN` don't trigger other workflows (GitHub security limitation). This caused the Replicated Release workflow to never run after release-please created a tag.

**Fix:** release-please directly calls the Replicated Release workflow via `workflow_call` when a release is created. No PAT needed.

**Flow:**
```
merge to main → release-please updates Release PR
merge Release PR → release-please creates tag + GitHub Release
                 → triggers Replicated Release via workflow_call
                   → build images, create Replicated release, test on CMX
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)