### PR TITLE
fix: use build output version for helm install in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -177,12 +177,12 @@ jobs:
             --username "${EMAIL}" \
             --password "${LICENSE_ID}"
 
-          CHART_VERSION=$(grep '^version:' chart/Chart.yaml | awk '{print $2}')
-          echo "Chart version: ${CHART_VERSION}"
+          VERSION="${{ needs.build-and-push.outputs.version }}"
+          echo "Installing chart version: ${VERSION}"
 
           helm install drone-rx \
             oci://registry.replicated.com/${REPLICATED_APP}/${{ needs.create-release.outputs.channel }}/drone-rx \
-            --version "${CHART_VERSION}" \
+            --version "${VERSION}" \
             --namespace default \
             --timeout 10m || true
 


### PR DESCRIPTION
The test-on-cmx job was reading chart version from Chart.yaml in the repo (stale `1.0.0`), not the version from the build output (`1.2.1`). This caused `helm install` to look for the wrong version in the Replicated registry.

Fix: use `needs.build-and-push.outputs.version` consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)