### PR TITLE
fix: SDK response parsing, GH release tag, license field types

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -260,7 +260,6 @@ jobs:
   attach-chart:
     runs-on: ubuntu-latest
     needs: [build-and-push, promote-to-unstable]
-    if: ${{ github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -270,7 +269,7 @@ jobs:
           helm repo add nats https://nats-io.github.io/k8s/helm/charts
           helm repo update
 
-      - name: Package and attach Helm chart to GitHub Release
+      - name: Package Helm chart
         run: |
           VERSION="${{ needs.build-and-push.outputs.version }}"
           helm dependency build chart/
@@ -279,5 +278,6 @@ jobs:
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ needs.build-and-push.outputs.version }}
           files: |
             drone-rx-${{ needs.build-and-push.outputs.version }}.tgz

--- a/internal/handlers/license.go
+++ b/internal/handlers/license.go
@@ -43,10 +43,10 @@ func (h *LicenseHandler) Status(w http.ResponseWriter, r *http.Request) {
 	liveTracking := h.client.IsFeatureEnabled("live_tracking_enabled")
 
 	json.NewEncoder(w).Encode(licenseStatusResponse{
-		Valid:               true,
-		Expired:             info.IsExpired,
+		Valid:               !info.IsExpired(),
+		Expired:             info.IsExpired(),
 		LicenseType:         info.LicenseType,
-		ExpirationDate:      info.ExpirationDate,
+		ExpirationDate:      info.ExpirationDate(),
 		LiveTrackingEnabled: liveTracking,
 	})
 }

--- a/internal/sdk/client.go
+++ b/internal/sdk/client.go
@@ -11,9 +11,9 @@ import (
 
 // LicenseField represents a single license field from the Replicated SDK.
 type LicenseField struct {
-	Name      string `json:"name"`
-	Value     string `json:"value"`
-	ValueType string `json:"valueType"`
+	Name      string      `json:"name"`
+	Value     interface{} `json:"value"`
+	ValueType string      `json:"valueType"`
 }
 
 // LicenseInfo holds top-level license metadata.
@@ -128,12 +128,23 @@ func (c *Client) SendMetrics(data map[string]interface{}) error {
 	return nil
 }
 
-// IsFeatureEnabled returns true if the named license field is "true" or "1".
+// IsFeatureEnabled returns true if the named license field is truthy.
+// Handles both boolean (true) and string ("true", "1") values from the SDK.
 // Returns false on any error (fail closed).
 func (c *Client) IsFeatureEnabled(fieldName string) bool {
 	field, err := c.GetLicenseField(fieldName)
 	if err != nil {
+		log.Printf("sdk: feature check %s failed: %v", fieldName, err)
 		return false
 	}
-	return field.Value == "true" || field.Value == "1"
+	switch v := field.Value.(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true" || v == "1"
+	case float64:
+		return v == 1
+	default:
+		return false
+	}
 }

--- a/internal/sdk/client.go
+++ b/internal/sdk/client.go
@@ -16,13 +16,46 @@ type LicenseField struct {
 	ValueType string      `json:"valueType"`
 }
 
+// LicenseEntitlement represents a single entitlement in the license info response.
+type LicenseEntitlement struct {
+	Title     string      `json:"title"`
+	Value     interface{} `json:"value"`
+	ValueType string      `json:"valueType"`
+}
+
 // LicenseInfo holds top-level license metadata.
 type LicenseInfo struct {
-	LicenseID      string `json:"licenseId"`
-	ChannelName    string `json:"channelName"`
-	LicenseType    string `json:"licenseType"`
-	IsExpired      bool   `json:"isExpired"`
-	ExpirationDate string `json:"expirationDate"`
+	LicenseID    string                        `json:"licenseID"`
+	ChannelName  string                        `json:"channelName"`
+	LicenseType  string                        `json:"licenseType"`
+	Entitlements map[string]LicenseEntitlement  `json:"entitlements"`
+}
+
+// IsExpired checks if the license has passed its expiration date.
+func (l *LicenseInfo) IsExpired() bool {
+	ea, ok := l.Entitlements["expires_at"]
+	if !ok {
+		return false
+	}
+	dateStr, ok := ea.Value.(string)
+	if !ok || dateStr == "" {
+		return false
+	}
+	expiry, err := time.Parse(time.RFC3339, dateStr)
+	if err != nil {
+		return false
+	}
+	return time.Now().After(expiry)
+}
+
+// ExpirationDate returns the expiration date string, or empty if none set.
+func (l *LicenseInfo) ExpirationDate() string {
+	ea, ok := l.Entitlements["expires_at"]
+	if !ok {
+		return ""
+	}
+	dateStr, _ := ea.Value.(string)
+	return dateStr
 }
 
 // UpdateInfo describes an available application update.

--- a/internal/sdk/client_test.go
+++ b/internal/sdk/client_test.go
@@ -47,13 +47,14 @@ func TestClient_GetLicenseInfo(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(sdk.LicenseInfo{
-			LicenseID:      "abc123",
-			ChannelName:    "Stable",
-			LicenseType:    "prod",
-			IsExpired:      false,
-			ExpirationDate: "2027-01-01",
-		})
+		w.Write([]byte(`{
+			"licenseID": "abc123",
+			"channelName": "Stable",
+			"licenseType": "prod",
+			"entitlements": {
+				"expires_at": {"title": "Expiration", "value": "2027-01-01T00:00:00Z", "valueType": "String"}
+			}
+		}`))
 	}))
 	defer srv.Close()
 
@@ -71,8 +72,34 @@ func TestClient_GetLicenseInfo(t *testing.T) {
 	if info.LicenseType != "prod" {
 		t.Errorf("expected LicenseType prod, got %s", info.LicenseType)
 	}
-	if info.IsExpired {
-		t.Error("expected IsExpired false")
+	if info.IsExpired() {
+		t.Error("expected not expired (expires 2027)")
+	}
+	if info.ExpirationDate() != "2027-01-01T00:00:00Z" {
+		t.Errorf("expected expiration date, got %s", info.ExpirationDate())
+	}
+}
+
+func TestClient_LicenseInfo_Expired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"licenseID": "expired123",
+			"licenseType": "trial",
+			"entitlements": {
+				"expires_at": {"title": "Expiration", "value": "2020-01-01T00:00:00Z", "valueType": "String"}
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	client := sdk.NewClient(srv.URL)
+	info, err := client.GetLicenseInfo()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !info.IsExpired() {
+		t.Error("expected expired (expires 2020)")
 	}
 }
 


### PR DESCRIPTION
## Summary

### SDK response parsing fixes (2.5, 2.6)
- **Boolean license fields:** SDK returns JSON `true` (boolean), not `"true"` (string). Changed `LicenseField.Value` to `interface{}` with type switch handling
- **License ID casing:** SDK returns `"licenseID"` (capital D), not `"licenseId"`. Fixed JSON struct tag
- **Expiry detection:** SDK `/license/info` has no `isExpired` field. Expiry is in `entitlements.expires_at.value`. Added `IsExpired()` and `ExpirationDate()` methods that parse the entitlement

### GitHub Release fix
- Added explicit `tag_name` to `softprops/action-gh-release` — needed when triggered via `workflow_call` (no tag in context)
- Removed `if: push` gate on attach-chart job

### Tests
- Added expired license test scenario
- All 27 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)