### PR TITLE
fix: faster ticker, animated flight path, polished premium tracking

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,7 +12,7 @@ api:
     limits:
       cpu: 500m
       memory: 256Mi
-  tickerInterval: 10
+  tickerInterval: 5
   webhookURL: ""
 
 frontend:

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -174,20 +174,16 @@ body {
   pointer-events: none;
 }
 
-/* Confetti celebration */
-@keyframes confetti-fall {
-  0% { transform: translateY(-10px) rotate(0deg); opacity: 1; }
-  100% { transform: translateY(100vh) rotate(720deg); opacity: 0; }
-}
-
-.confetti-piece {
-  position: absolute;
-  top: -10px;
-  width: 8px;
-  height: 8px;
-  opacity: 0;
-  animation: confetti-fall var(--duration) ease-in var(--delay) forwards;
-  left: var(--x);
+/* Sparkle burst from delivered icon */
+@keyframes sparkle-burst {
+  0% { transform: translate(-50%, -50%) rotate(0deg) scale(1); opacity: 1; }
+  100% {
+    transform: translate(
+      calc(-50% + cos(var(--angle)) * var(--distance)),
+      calc(-50% + sin(var(--angle)) * var(--distance))
+    ) rotate(360deg) scale(0);
+    opacity: 0;
+  }
 }
 
 /* Delivery text scale-up */

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -174,14 +174,11 @@ body {
   pointer-events: none;
 }
 
-/* Sparkle burst from delivered icon */
+/* Sparkle burst from delivered icon — uses pre-computed --tx/--ty for browser compat */
 @keyframes sparkle-burst {
-  0% { transform: translate(-50%, -50%) rotate(0deg) scale(1); opacity: 1; }
+  0% { transform: translate(-50%, -50%) scale(1); opacity: 1; }
   100% {
-    transform: translate(
-      calc(-50% + cos(var(--angle)) * var(--distance)),
-      calc(-50% + sin(var(--angle)) * var(--distance))
-    ) rotate(360deg) scale(0);
+    transform: translate(calc(-50% + var(--tx)), calc(-50% + var(--ty))) scale(0);
     opacity: 0;
   }
 }
@@ -217,4 +214,27 @@ body {
     linear-gradient(rgba(51, 69, 128, 0.1) 1px, transparent 1px),
     linear-gradient(90deg, rgba(51, 69, 128, 0.1) 1px, transparent 1px);
   background-size: 40px 40px;
+}
+
+/* Accessibility — disable decorative animations for users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .animate-drone-fly,
+  .animate-drone-float,
+  .animate-drone-pulse,
+  .animate-rotor-spin,
+  .animate-progress-glow,
+  .animate-countdown-pulse,
+  .animate-step-complete,
+  .animate-connector-flash,
+  .animate-celebrate-scale,
+  .animate-drone-land,
+  .sparkle-particle {
+    animation: none !important;
+  }
+
+  /* Keep Tailwind's animate-ping and animate-pulse respecting the preference */
+  .animate-ping,
+  .animate-pulse {
+    animation: none !important;
+  }
 }

--- a/frontend/src/routes/order/[id]/+page.svelte
+++ b/frontend/src/routes/order/[id]/+page.svelte
@@ -17,6 +17,7 @@
 
 	// Premium live countdown state
 	let countdownSeconds = $state<number | null>(null);
+	let initialTotalSeconds = $state<number | null>(null); // total from order placement to delivery
 	let countdownInterval: ReturnType<typeof setInterval> | null = null;
 	let countdownTick = $state(0); // increments each second to trigger pulse
 
@@ -53,6 +54,10 @@
 	function startCountdown(initialSeconds: number) {
 		stopCountdown();
 		countdownSeconds = Math.max(0, initialSeconds);
+		// Only set initial total on first call — don't reset on status updates
+		if (initialTotalSeconds == null) {
+			initialTotalSeconds = Math.max(0, initialSeconds);
+		}
 		countdownInterval = setInterval(() => {
 			if (countdownSeconds != null && countdownSeconds > 0) {
 				countdownSeconds--;
@@ -177,12 +182,9 @@
 	// Drone flight progress (0 to 1) derived from countdown
 	let flightProgress = $derived.by(() => {
 		if (!trackingEnabled || order.status !== 'in-flight') return 0;
-		if (countdownSeconds == null || order.remaining_eta_seconds == null) return 0.5;
-		// remaining_eta_seconds is the initial ETA; countdownSeconds ticks down
-		const total = order.remaining_eta_seconds;
-		if (total <= 0) return 1;
-		const elapsed = total - countdownSeconds;
-		return Math.min(1, Math.max(0, elapsed / total));
+		if (countdownSeconds == null || initialTotalSeconds == null || initialTotalSeconds <= 0) return 0.5;
+		const elapsed = initialTotalSeconds - countdownSeconds;
+		return Math.min(1, Math.max(0, elapsed / initialTotalSeconds));
 	});
 
 	// Confetti pieces configuration

--- a/frontend/src/routes/order/[id]/+page.svelte
+++ b/frontend/src/routes/order/[id]/+page.svelte
@@ -202,17 +202,6 @@
 	<title>DroneRx — Order #{order.id.slice(0, 8)}</title>
 </svelte:head>
 
-<!-- Confetti overlay (premium delivery celebration) -->
-{#if trackingEnabled && showConfetti}
-	<div class="fixed inset-0 pointer-events-none z-50 overflow-hidden">
-		{#each confettiPieces as piece}
-			<div
-				class="confetti-piece {piece.shape} {piece.size}"
-				style="--x: {piece.x}; --delay: {piece.delay}; --duration: {piece.duration}; background: {piece.color}; left: {piece.x};"
-			></div>
-		{/each}
-	</div>
-{/if}
 
 <!-- Header -->
 <header class="border-b border-navy-700/60 bg-navy-900/80 backdrop-blur-xl">
@@ -280,13 +269,28 @@
 			{:else if order.status === 'delivered'}
 				<div class="text-right">
 					{#if trackingEnabled && showCelebration}
-						<!-- Premium: celebration delivery -->
-						<div class="animate-celebrate-scale">
+						<!-- Premium: celebration delivery with localized sparkles -->
+						<div class="relative animate-celebrate-scale">
 							<div class="w-12 h-12 rounded-full bg-emerald-500/20 border-2 border-emerald-400 flex items-center justify-center mb-1 ml-auto shadow-lg shadow-emerald-500/30">
 								<svg class="w-6 h-6 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
 								</svg>
 							</div>
+							{#if showConfetti}
+								{#each confettiPieces.slice(0, 16) as piece, i}
+									<span
+										class="absolute pointer-events-none {piece.shape} {piece.size}"
+										style="
+											top: 50%; left: 50%;
+											background: {piece.color};
+											animation: sparkle-burst {0.6 + Math.random() * 0.8}s ease-out forwards;
+											animation-delay: {Math.random() * 0.3}s;
+											--angle: {(i / 16) * 360}deg;
+											--distance: {30 + Math.random() * 40}px;
+										"
+									></span>
+								{/each}
+							{/if}
 							<p class="text-sm font-bold text-emerald-400">Delivered!</p>
 						</div>
 					{:else}

--- a/frontend/src/routes/order/[id]/+page.svelte
+++ b/frontend/src/routes/order/[id]/+page.svelte
@@ -187,8 +187,8 @@
 		return Math.min(1, Math.max(0, elapsed / initialTotalSeconds));
 	});
 
-	// Confetti pieces configuration
-	const confettiPieces = Array.from({ length: 30 }, (_, i) => ({
+	// Sparkle-burst pieces configuration (16 particles radiate from delivered icon)
+	const confettiPieces = Array.from({ length: 16 }, (_, i) => ({
 		x: `${Math.random() * 100}%`,
 		delay: `${Math.random() * 1.5}s`,
 		duration: `${2 + Math.random() * 2}s`,
@@ -277,16 +277,21 @@
 								</svg>
 							</div>
 							{#if showConfetti}
-								{#each confettiPieces.slice(0, 16) as piece, i}
+								{@const burstParticles = confettiPieces.map((piece, i) => {
+									const angle = (i / 16) * 2 * Math.PI;
+									const dist = 30 + Math.random() * 40;
+									return { ...piece, tx: Math.cos(angle) * dist, ty: Math.sin(angle) * dist, dur: 0.6 + Math.random() * 0.8, delay: Math.random() * 0.3 };
+								})}
+								{#each burstParticles as p}
 									<span
-										class="absolute pointer-events-none {piece.shape} {piece.size}"
+										class="absolute pointer-events-none {p.shape} {p.size}"
 										style="
 											top: 50%; left: 50%;
-											background: {piece.color};
-											animation: sparkle-burst {0.6 + Math.random() * 0.8}s ease-out forwards;
-											animation-delay: {Math.random() * 0.3}s;
-											--angle: {(i / 16) * 360}deg;
-											--distance: {30 + Math.random() * 40}px;
+											background: {p.color};
+											animation: sparkle-burst {p.dur}s ease-out forwards;
+											animation-delay: {p.delay}s;
+											--tx: {p.tx.toFixed(1)}px;
+											--ty: {p.ty.toFixed(1)}px;
 										"
 									></span>
 								{/each}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,7 @@ func Load() Config {
 		Port:           getEnv("PORT", "8080"),
 		DatabaseURL:    getEnv("DATABASE_URL", ""),
 		NATSUrl:        getEnv("NATS_URL", "nats://localhost:4222"),
-		TickerInterval: getEnvInt("TICKER_INTERVAL", 10),
+		TickerInterval: getEnvInt("TICKER_INTERVAL", 5),
 		WebhookURL:     getEnv("WEBHOOK_URL", ""),
 		SDKUrl:         getEnv("REPLICATED_SDK_URL", "http://drone-rx-sdk:3000"),
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,8 +18,8 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.NATSUrl != "nats://localhost:4222" {
 		t.Errorf("expected default NATS URL, got %s", cfg.NATSUrl)
 	}
-	if cfg.TickerInterval != 10 {
-		t.Errorf("expected default ticker interval 10, got %d", cfg.TickerInterval)
+	if cfg.TickerInterval != 5 {
+		t.Errorf("expected default ticker interval 5, got %d", cfg.TickerInterval)
 	}
 	if cfg.WebhookURL != "" {
 		t.Errorf("expected empty WebhookURL, got %s", cfg.WebhookURL)


### PR DESCRIPTION
## Summary

### Ticker interval
- Reduced from 10s to 5s — full delivery completes in ~15s

### Premium tracking animation fixes
- **Flight path** — drone now smoothly animates from pharmacy to home using initial total ETA (was stuck due to resetting progress on each poll)
- **Sparkle burst** — replaced full-screen confetti with localized particle burst from the delivered icon
- **Browser compat** — replaced CSS `cos()`/`sin()` with pre-computed `--tx`/`--ty` from JS
- **Accessibility** — added `prefers-reduced-motion` media query to disable all animations
- **Cleanup** — trimmed unused confetti array, removed dead CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)