### PR TITLE
feat: add structured JSON logging to frontend

### DIFF
--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -2,30 +2,67 @@ import type { Handle } from '@sveltejs/kit';
 
 const API_URL = process.env.API_URL || 'http://localhost:8080';
 
+function log(level: string, msg: string, data: Record<string, unknown> = {}) {
+	const entry = { time: new Date().toISOString(), level, msg, ...data };
+	console.log(JSON.stringify(entry));
+}
+
 export const handle: Handle = async ({ event, resolve }) => {
+	const start = Date.now();
 	const { pathname } = event.url;
 
 	if (pathname.startsWith('/api') || pathname === '/healthz') {
 		const target = `${API_URL}${pathname}${event.url.search}`;
 
-		// Pass through WebSocket upgrade requests
 		const headers = new Headers(event.request.headers);
 		headers.set('host', new URL(API_URL).host);
 
-		const response = await fetch(target, {
-			method: event.request.method,
-			headers,
-			body: event.request.method !== 'GET' && event.request.method !== 'HEAD'
-				? await event.request.text()
-				: undefined,
-		});
+		try {
+			const response = await fetch(target, {
+				method: event.request.method,
+				headers,
+				body: event.request.method !== 'GET' && event.request.method !== 'HEAD'
+					? await event.request.text()
+					: undefined,
+			});
 
-		return new Response(response.body, {
+			const duration = Date.now() - start;
+			if (pathname !== '/healthz' && pathname !== '/api/updates' && pathname !== '/api/license/status') {
+				log('INFO', 'api proxy', {
+					method: event.request.method,
+					path: pathname,
+					status: response.status,
+					duration_ms: duration,
+				});
+			}
+
+			return new Response(response.body, {
+				status: response.status,
+				statusText: response.statusText,
+				headers: response.headers,
+			});
+		} catch (err) {
+			log('ERROR', 'api proxy failed', {
+				method: event.request.method,
+				path: pathname,
+				error: err instanceof Error ? err.message : String(err),
+			});
+			return new Response('Backend unavailable', { status: 502 });
+		}
+	}
+
+	const response = await resolve(event);
+	const duration = Date.now() - start;
+
+	// Log page requests (skip static assets)
+	if (!pathname.startsWith('/_app/') && !pathname.startsWith('/favicon') && pathname !== '/robots.txt') {
+		log('INFO', 'page request', {
+			method: event.request.method,
+			path: pathname,
 			status: response.status,
-			statusText: response.statusText,
-			headers: response.headers,
+			duration_ms: duration,
 		});
 	}
 
-	return resolve(event);
+	return response;
 };


### PR DESCRIPTION
## Summary

Frontend had zero logs (`Listening on :3000` only). Added structured JSON logging matching the API format.

### What's logged

| Event | Details |
|-------|---------|
| **Page requests** | Method, path, status, duration (skips static assets) |
| **API proxy** | Method, path, status, duration (skips healthz, updates, license) |
| **Proxy errors** | Method, path, error message — returns 502 |

### Example output

```json
{"time":"...","level":"INFO","msg":"page request","method":"GET","path":"/","status":200,"duration_ms":12}
{"time":"...","level":"INFO","msg":"api proxy","method":"POST","path":"/api/orders","status":201,"duration_ms":45}
{"time":"...","level":"ERROR","msg":"api proxy failed","method":"GET","path":"/api/medicines","error":"fetch failed"}
```

Prepares for Tier 3 support bundle log collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)