### PR TITLE
fix: consolidate DB toggles into single postgresql.enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,24 +74,7 @@ Open http://localhost:5173
 
 ## Helm Chart
 
-### Install on an existing cluster
-
-```bash
-# Install CloudNativePG operator first
-helm repo add cnpg https://cloudnative-pg.github.io/charts
-helm install cnpg-operator cnpg/cloudnative-pg -n cnpg-system --create-namespace --wait
-
-# Install DroneRx
-helm dependency build chart/
-helm install dronerx chart/ \
-  --namespace dronerx \
-  --create-namespace \
-  --set cloudnativepg.enabled=false \
-  --set api.image.tag=0.1.0 \
-  --set frontend.image.tag=0.1.0
-```
-
-### Install with bundled operator
+### Install with embedded PostgreSQL
 
 ```bash
 helm dependency build chart/
@@ -101,6 +84,20 @@ helm install dronerx chart/ \
   --set api.image.tag=0.1.0 \
   --set frontend.image.tag=0.1.0 \
   --timeout 5m
+```
+
+### Install with external database (e.g. Neon)
+
+```bash
+helm dependency build chart/
+helm install dronerx chart/ \
+  --namespace dronerx \
+  --create-namespace \
+  --set postgresql.enabled=false \
+  --set externalDatabase.host=ep-XXXXX.us-east-2.aws.neon.tech \
+  --set externalDatabase.password=YOUR_PASSWORD \
+  --set api.image.tag=0.1.0 \
+  --set frontend.image.tag=0.1.0
 ```
 
 ### Configuration

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: replicated
   repository: oci://registry.replicated.com/library
   version: 1.19.1
-digest: sha256:484493561849101571fc7d48d200f213e037c47a111cbb7f595927f8db295353
-generated: "2026-04-09T06:47:30.080891+12:00"
+digest: sha256:11955091fba699199ca41c62793bb25acf75f65e297d41a075d965a84b00a4ea
+generated: "2026-04-12T13:13:19.614115+12:00"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   - name: cloudnative-pg
     version: "0.28.0"
     repository: "https://cloudnative-pg.github.io/charts"
-    condition: cloudnativepg.enabled
+    condition: postgresql.enabled
   - name: nats
     version: "2.12.6"
     repository: "https://nats-io.github.io/k8s/helm/charts"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -76,16 +76,33 @@ app.kubernetes.io/component: frontend
 {{- end }}
 
 {{/*
+Database configuration guard.
+Fails if postgresql is disabled but no external host is provided,
+or if postgresql is enabled but an external host is also set.
+Called automatically by the dronerx.databaseURL helper.
+*/}}
+{{- define "dronerx.validateDatabase" -}}
+{{- if and .Values.postgresql.enabled .Values.externalDatabase.host -}}
+  {{- fail "Invalid configuration: postgresql.enabled=true and externalDatabase.host are mutually exclusive. Disable embedded postgres or remove externalDatabase.host." -}}
+{{- end -}}
+{{- if and (not .Values.postgresql.enabled) (not .Values.externalDatabase.host) -}}
+  {{- fail "Invalid configuration: postgresql.enabled=false but externalDatabase.host is not set. Either enable embedded postgres or provide an external database host." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Database URL helper.
-Uses external DB if cloudnativepg is disabled, otherwise points to the CNPG cluster service.
+Uses CNPG cluster when postgresql.enabled=true, otherwise external DB.
 */}}
 {{- define "dronerx.databaseURL" -}}
-{{- if .Values.cloudnativepg.enabled }}
-{{- printf "postgres://dronerx:$(DB_PASSWORD)@%s-db-rw:5432/dronerx?sslmode=disable" (include "dronerx.fullname" .) }}
-{{- else }}
-{{- printf "postgres://%s:$(DB_PASSWORD)@%s:%d/%s?sslmode=disable" .Values.externalDatabase.user .Values.externalDatabase.host (int .Values.externalDatabase.port) .Values.externalDatabase.name }}
-{{- end }}
-{{- end }}
+{{- include "dronerx.validateDatabase" . -}}
+{{- if .Values.postgresql.enabled -}}
+{{/* sslmode=disable is correct for cluster-local CNPG traffic */}}
+{{- printf "postgres://dronerx:$(DB_PASSWORD)@%s-db-rw:5432/dronerx?sslmode=disable" (include "dronerx.fullname" .) -}}
+{{- else -}}
+{{- printf "postgres://%s:$(DB_PASSWORD)@%s:%d/%s?sslmode=%s" .Values.externalDatabase.user .Values.externalDatabase.host (int .Values.externalDatabase.port) .Values.externalDatabase.name (.Values.externalDatabase.sslmode | default "require") -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 NATS URL helper.

--- a/chart/templates/api-deployment.yaml
+++ b/chart/templates/api-deployment.yaml
@@ -52,7 +52,7 @@ spec:
                   key: password
                   {{- end }}
             - name: DATABASE_URL
-              value: "postgres://dronerx:$(DB_PASSWORD)@{{ include "dronerx.fullname" . }}-db-rw:5432/dronerx?sslmode=disable"
+              value: "{{ include "dronerx.databaseURL" . }}"
           livenessProbe:
             httpGet:
               path: /healthz

--- a/chart/templates/wait-for-cnpg-job.yaml
+++ b/chart/templates/wait-for-cnpg-job.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.postgresql.enabled .Values.cloudnativepg.enabled }}
+{{- if .Values.postgresql.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -179,19 +179,9 @@
         }
       }
     },
-    "cloudnativepg": {
-      "type": "object",
-      "description": "CloudNativePG operator subchart toggle. Must match postgresql.enabled.",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Deploy the CloudNativePG operator"
-        }
-      }
-    },
     "postgresql": {
       "type": "object",
-      "description": "Embedded PostgreSQL via CloudNativePG. Set enabled=false and configure externalDatabase for BYO Postgres.",
+      "description": "Embedded PostgreSQL via CloudNativePG. Controls both the operator subchart and Cluster CR. Set enabled=false and configure externalDatabase for BYO Postgres.",
       "properties": {
         "enabled": {
           "type": "boolean",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -181,7 +181,7 @@
     },
     "cloudnativepg": {
       "type": "object",
-      "description": "CloudNativePG operator subchart toggle",
+      "description": "CloudNativePG operator subchart toggle. Must match postgresql.enabled.",
       "properties": {
         "enabled": {
           "type": "boolean",
@@ -191,7 +191,7 @@
     },
     "postgresql": {
       "type": "object",
-      "description": "PostgreSQL cluster configuration",
+      "description": "Embedded PostgreSQL via CloudNativePG. Set enabled=false and configure externalDatabase for BYO Postgres.",
       "properties": {
         "enabled": {
           "type": "boolean",
@@ -215,7 +215,7 @@
     },
     "externalDatabase": {
       "type": "object",
-      "description": "External database connection details (used when cloudnativepg.enabled=false)",
+      "description": "External (BYO) PostgreSQL connection. Required when postgresql.enabled=false.",
       "properties": {
         "host": {
           "type": "string",
@@ -238,6 +238,12 @@
         "password": {
           "type": "string",
           "description": "Database password"
+        },
+        "sslmode": {
+          "type": "string",
+          "enum": ["disable", "require", "verify-ca", "verify-full"],
+          "default": "require",
+          "description": "PostgreSQL SSL mode (require for Neon and most cloud providers)"
         }
       }
     },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -50,9 +50,7 @@ cloudnative-pg:
 
 # -- Embedded PostgreSQL (CloudNativePG).
 # Set postgresql.enabled=false and configure externalDatabase to use BYO Postgres.
-cloudnativepg:
-  enabled: true
-
+# This toggle controls both the CNPG operator subchart and the Cluster CR.
 postgresql:
   enabled: true
   instances: 1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -48,6 +48,8 @@ cloudnative-pg:
     repository: images.littleroom.co.nz/anonymous/ghcr.io/cloudnative-pg/cloudnative-pg
   imagePullSecrets: []
 
+# -- Embedded PostgreSQL (CloudNativePG).
+# Set postgresql.enabled=false and configure externalDatabase to use BYO Postgres.
 cloudnativepg:
   enabled: true
 
@@ -57,12 +59,16 @@ postgresql:
   storage:
     size: 1Gi
 
+# -- External (BYO) PostgreSQL connection.
+# Only used when postgresql.enabled=false.
+# All fields are required when using external database.
 externalDatabase:
   host: ""
   port: 5432
   name: "dronerx"
   user: "dronerx"
   password: ""
+  sslmode: "require"
 
 imagePullSecrets: []
 


### PR DESCRIPTION
## Summary

- Consolidate the inconsistent `postgresql.enabled` / `cloudnativepg.enabled` toggles into a single `postgresql.enabled` flag that controls both the CNPG operator subchart and the Cluster CR
- Add a `validateDatabase` fail-guard template that blocks install on conflicting config (both enabled, or neither configured)
- Wire `api-deployment.yaml` to use the `databaseURL` helper instead of a hardcoded URL
- Add `externalDatabase.sslmode` field (default `require`) for Neon and cloud Postgres compatibility
- Update README install examples for embedded vs external DB paths

## Test Plan

- [ ] `helm template` with default values renders CNPG operator, Cluster CR, wait job, init container, and embedded DATABASE_URL with `sslmode=disable`
- [ ] `helm template` with `postgresql.enabled=false` + `externalDatabase.host` renders no CNPG resources, uses db-credentials secret, and DATABASE_URL with `sslmode=require`
- [ ] Guard fires "mutually exclusive" error when both `postgresql.enabled=true` and `externalDatabase.host` are set
- [ ] Guard fires "not set" error when `postgresql.enabled=false` and no `externalDatabase.host`
- [ ] Custom `sslmode` override (e.g. `verify-full`) propagates to DATABASE_URL
- [ ] `helm lint` passes on both embedded and external paths
- [ ] Go tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)