### PR TITLE
fix: opt into Node.js 24 for release-please action

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -9,6 +9,9 @@ permissions:
   pull-requests: write
   packages: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Node.js 20 is deprecated for GitHub Actions. Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to suppress the warning and use Node 24 now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)