### PR TITLE
fix: Tier 3 Phase 1 — Secret wrappers, file paths, and collector fixes

### DIFF
--- a/chart/templates/_preflight.tpl
+++ b/chart/templates/_preflight.tpl
@@ -127,4 +127,17 @@ spec:
                 Supported distributions: EKS, GKE, AKS, RKE2, k3s, OpenShift.
           - pass:
               message: Kubernetes distribution is supported.
+    {{- /* Default storage class (always) */}}
+    - storageClass:
+        checkName: Default Storage Class
+        outcomes:
+          - fail:
+              when: "== false"
+              message: |
+                No default storage class is configured on this cluster.
+                DroneRx requires a default storage class for PostgreSQL persistent volume claims.
+                Configure a default storage class:
+                  kubectl patch storageclass <name> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+          - pass:
+              message: A default storage class is available.
 {{- end }}

--- a/chart/templates/_preflight.tpl
+++ b/chart/templates/_preflight.tpl
@@ -4,6 +4,7 @@ kind: Preflight
 metadata:
   name: {{ include "dronerx.fullname" . }}-preflight
 spec:
+  {{- if or (not .Values.postgresql.enabled) .Values.ingress.tls.cloudflare.enabled }}
   collectors:
     {{- /* 3.1a: External DB connectivity collector (conditional) */}}
     {{- if not .Values.postgresql.enabled }}
@@ -25,12 +26,13 @@ spec:
           - |
             nc -zv api.cloudflare.com 443 2>&1 && echo "connected" || echo "connection_failed"
     {{- end }}
+  {{- end }}
   analyzers:
     {{- /* 3.1a: External DB connectivity analyzer (conditional) */}}
     {{- if not .Values.postgresql.enabled }}
     - textAnalyze:
         checkName: External Database Connectivity
-        fileName: preflight/dronerx-db-check.txt
+        fileName: dronerx-db-check/stdout.txt
         regex: "connected"
         outcomes:
           - fail:
@@ -47,7 +49,7 @@ spec:
     {{- if .Values.ingress.tls.cloudflare.enabled }}
     - textAnalyze:
         checkName: Cloudflare API Connectivity
-        fileName: preflight/dronerx-cloudflare-check.txt
+        fileName: dronerx-cloudflare-check/stdout.txt
         regex: "connected"
         outcomes:
           - fail:

--- a/chart/templates/_preflight.tpl
+++ b/chart/templates/_preflight.tpl
@@ -32,7 +32,7 @@ spec:
     {{- if not .Values.postgresql.enabled }}
     - textAnalyze:
         checkName: External Database Connectivity
-        fileName: dronerx-db-check/stdout.txt
+        fileName: dronerx-db-check.log
         regex: "connected"
         outcomes:
           - fail:
@@ -49,7 +49,7 @@ spec:
     {{- if .Values.ingress.tls.cloudflare.enabled }}
     - textAnalyze:
         checkName: Cloudflare API Connectivity
-        fileName: dronerx-cloudflare-check/stdout.txt
+        fileName: dronerx-cloudflare-check.log
         regex: "connected"
         outcomes:
           - fail:

--- a/chart/templates/_supportbundle.tpl
+++ b/chart/templates/_supportbundle.tpl
@@ -51,7 +51,7 @@ spec:
     {{- /* 3.3: Health endpoint analyzer */}}
     - textAnalyze:
         checkName: Application Health Endpoint
-        fileName: http/dronerx-health.json
+        fileName: dronerx-health.json
         regex: '"status":\s*"ok"'
         outcomes:
           - fail:
@@ -92,7 +92,7 @@ spec:
     - textAnalyze:
         checkName: Database and NATS Connection Failures
         fileName: dronerx/api-logs/*/*
-        regex: 'database:.*|nats:.*|NATS not connected'
+        regex: '"level":"ERROR".*database|"level":"ERROR".*nats|NATS not connected'
         outcomes:
           - fail:
               when: "true"

--- a/chart/templates/preflight.yaml
+++ b/chart/templates/preflight.yaml
@@ -1,9 +1,3 @@
-{{- /* Standalone resource for KOTS/EC (CRDs exist) */}}
-{{- if .Capabilities.APIVersions.Has "troubleshoot.sh/v1beta2" }}
-{{ include "dronerx.preflight" . }}
-{{- end }}
----
-{{- /* Secret-wrapped spec for Helm CLI installs (no CRDs) */}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/templates/preflight.yaml
+++ b/chart/templates/preflight.yaml
@@ -12,5 +12,5 @@ metadata:
     {{- include "dronerx.labels" . | nindent 4 }}
     troubleshoot.sh/kind: preflight
 stringData:
-  preflight.yaml: |
+  preflight-spec: |
     {{ include "dronerx.preflight" . | nindent 4 }}

--- a/chart/templates/preflight.yaml
+++ b/chart/templates/preflight.yaml
@@ -1,3 +1,16 @@
+{{- /* Standalone resource for KOTS/EC (CRDs exist) */}}
 {{- if .Capabilities.APIVersions.Has "troubleshoot.sh/v1beta2" }}
 {{ include "dronerx.preflight" . }}
 {{- end }}
+---
+{{- /* Secret-wrapped spec for Helm CLI installs (no CRDs) */}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "dronerx.fullname" . }}-preflight
+  labels:
+    {{- include "dronerx.labels" . | nindent 4 }}
+    troubleshoot.sh/kind: preflight
+stringData:
+  preflight.yaml: |
+    {{ include "dronerx.preflight" . | nindent 4 }}

--- a/chart/templates/supportbundle.yaml
+++ b/chart/templates/supportbundle.yaml
@@ -12,5 +12,5 @@ metadata:
     {{- include "dronerx.labels" . | nindent 4 }}
     troubleshoot.sh/kind: support-bundle
 stringData:
-  support-bundle.yaml: |
+  support-bundle-spec: |
     {{ include "dronerx.supportbundle" . | nindent 4 }}

--- a/chart/templates/supportbundle.yaml
+++ b/chart/templates/supportbundle.yaml
@@ -1,9 +1,3 @@
-{{- /* Standalone resource for KOTS/EC (CRDs exist) */}}
-{{- if .Capabilities.APIVersions.Has "troubleshoot.sh/v1beta2" }}
-{{ include "dronerx.supportbundle" . }}
-{{- end }}
----
-{{- /* Secret-wrapped spec for Helm CLI installs (no CRDs) */}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/templates/supportbundle.yaml
+++ b/chart/templates/supportbundle.yaml
@@ -1,3 +1,16 @@
+{{- /* Standalone resource for KOTS/EC (CRDs exist) */}}
 {{- if .Capabilities.APIVersions.Has "troubleshoot.sh/v1beta2" }}
 {{ include "dronerx.supportbundle" . }}
 {{- end }}
+---
+{{- /* Secret-wrapped spec for Helm CLI installs (no CRDs) */}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "dronerx.fullname" . }}-supportbundle
+  labels:
+    {{- include "dronerx.labels" . | nindent 4 }}
+    troubleshoot.sh/kind: support-bundle
+stringData:
+  support-bundle.yaml: |
+    {{ include "dronerx.supportbundle" . | nindent 4 }}

--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -196,6 +196,51 @@ Pain points encountered while building and distributing a Helm-based app with Re
 
 ---
 
+## Tier 3 — Support It
+
+### Dual database toggles caused silent inconsistency
+**Problem:** The chart had two separate toggles — `cloudnativepg.enabled` (operator subchart) and `postgresql.enabled` (Cluster CR) — that always had to move together. The `databaseURL` helper checked one, all other templates checked the other. No valid combination existed where they differed.
+**Error:** No error — just a confusing developer experience and risk of misconfiguration.
+**Resolution:** Collapsed to single `postgresql.enabled` toggle. Changed Chart.yaml condition to `postgresql.enabled`, removed `cloudnativepg` from values/schema, simplified wait-for-cnpg-job condition.
+**Time spent:** ~30 minutes to identify, plan, and implement.
+**Lesson:** When a subchart exists solely to support one feature, tie its condition to the feature toggle, not a separate key.
+
+### Hardcoded sslmode=disable breaks cloud Postgres
+**Problem:** The `databaseURL` helper hardcoded `sslmode=disable` for both embedded and external DB paths. Neon (and most cloud Postgres providers) require `sslmode=require`.
+**Resolution:** Added `externalDatabase.sslmode` field (default `require`), used it in the external DB path. Kept `sslmode=disable` for embedded CNPG (cluster-local traffic).
+**Lesson:** Never hardcode connection parameters that differ between development and production.
+
+### Mutual exclusion guard too strict for pre-configured values
+**Problem:** Added a `fail` guard to prevent `postgresql.enabled=true` and `externalDatabase.host` being set simultaneously. But this prevented pre-configuring the Neon endpoint in values.yaml alongside the embedded default.
+**Resolution:** Relaxed the guard to only enforce the essential check — `postgresql.enabled=false` requires a host. Having external DB values alongside embedded postgres is fine (pre-configuration, not conflict).
+**Lesson:** Helm guards should prevent broken installs, not restrict how values are organized.
+
+### Troubleshoot CRDs don't exist on Helm CLI installs
+**Problem:** Added `preflight.yaml` and `supportbundle.yaml` as standalone `kind: Preflight` / `kind: SupportBundle` resources. CI Helm install failed because Troubleshoot CRDs don't exist on regular clusters — only in KOTS/EC environments.
+**Error:** `resource mapping not found for name: "***-preflight" namespace: "" from "": no matches for kind "Preflight" in version "troubleshoot.sh/v1beta2"`
+**Resolution:** Dual-mode rendering: (1) Standalone CRD resources gated on `.Capabilities.APIVersions.Has "troubleshoot.sh/v1beta2"` for KOTS/EC. (2) Kubernetes Secrets with `troubleshoot.sh/kind` labels for Helm CLI installs, discovered via `kubectl preflight --load-cluster-specs`.
+**Time spent:** ~20 minutes debugging CI failure + researching Replicated docs.
+**Lesson:** Troubleshoot specs need different delivery mechanisms for KOTS vs Helm CLI paths.
+
+### Preflight run collector output paths differ from support bundle
+**Problem:** `textAnalyze` fileName was set to `preflight/dronerx-db-check.txt` (based on reference docs), then changed to `dronerx-db-check/stdout.txt` (support bundle format). Neither matched the actual preflight output.
+**Error:** `No matching files` — collectors ran successfully but analyzers couldn't find the output.
+**Resolution:** Preflight `run` collectors write to `<collectorName>.log`, not `<collectorName>/stdout.txt` or `preflight/<collectorName>.txt`. Had to extract the actual preflight bundle and inspect file paths.
+**Time spent:** ~30 minutes across two incorrect attempts.
+**Lesson:** Always verify collector output paths by extracting a real bundle. Preflight and support bundle use different output path conventions for `run` collectors.
+
+### Empty collectors section triggers default collection
+**Problem:** When no conditional `run` collectors were active (embedded DB, no Cloudflare), the preflight spec rendered `collectors: []` (empty). The troubleshoot tool interprets this as "run default collectors" — gathering cluster info, pod logs, etc. — making preflights very slow.
+**Resolution:** Only render the `collectors:` section when at least one conditional collector is active. When no collectors are needed, omit the section entirely.
+**Time spent:** ~10 minutes.
+
+### Faking --api-versions doesn't fully work for testing
+**Problem:** Used `helm template --api-versions troubleshoot.sh/v1beta2` to render preflight specs for testing. The template rendered correctly but `kubectl preflight` didn't execute `run` collectors properly when fed the output.
+**Resolution:** Use the Secret-based approach for local testing. Apply the chart (or just the preflight secret) to the cluster, then run `kubectl preflight` pointing at the rendered spec via `yq` extraction or `--show-only`.
+**Time spent:** ~15 minutes.
+
+---
+
 ## General Observations
 
 ### What worked well
@@ -207,6 +252,9 @@ Pain points encountered while building and distributing a Helm-based app with Re
 - Testing CLI commands locally before embedding in CI workflows — saved hours of debugging
 - release-please for semver — clean flow, auto-CHANGELOG, version annotations in Chart.yaml and values.yaml
 - workflow_call chaining — elegant solution for GITHUB_TOKEN tag limitation
+- Named templates for troubleshoot specs — DRY pattern, same spec serves both KOTS CRD and Helm Secret delivery
+- Extracting preflight bundles to verify file paths — saved debugging time vs guessing
+- Single `postgresql.enabled` toggle — cleaner than two-toggle approach, less user confusion
 
 ### What could be improved
 - **Documentation inconsistency** — RBAC resource names shown in mixed case in docs but require lowercase in config
@@ -214,3 +262,5 @@ Pain points encountered while building and distributing a Helm-based app with Re
 - **Proxy registry auth** — not obvious that `registry.replicated.com` (OCI chart pull) and `proxy.replicated.com` (image proxy) are different auth domains
 - **Error messages** — many Replicated API errors are generic (403, 400) without indicating which specific permission is missing
 - **CLI `--auto` flag** — confusing that it ignores `.replicated` config rather than enhancing it
+- **Troubleshoot file path docs** — reference docs show `preflight/<collectorName>.txt` for run collectors but actual output is `<collectorName>.log`. Different format for preflights vs support bundles is not documented
+- **No CRDs on Helm installs** — not obvious that Troubleshoot CRDs only exist in KOTS/EC environments. The Secret-based discovery pattern for Helm installs isn't prominently documented


### PR DESCRIPTION
## Summary

Follow-up fixes from testing preflights and support bundles on real clusters:

- Wrap preflight/supportbundle specs in Kubernetes Secrets with `troubleshoot.sh/kind` labels for Helm CLI discovery (no CRDs needed)
- Fix run collector output paths: preflight uses `<collectorName>.log`, not `/stdout.txt`
- Omit empty `collectors:` section to avoid triggering slow default collection
- Fix health endpoint analyzer path: `dronerx-health.json` not `http/dronerx-health.json`
- Tighten DB/NATS failure regex to ERROR-level structured logs only (avoid false positive on nats_url in INFO)
- Add default storage class check to preflight
- Add Tier 3 friction log entries

## Test Plan

- [ ] `helm template` renders both CRD-gated resource AND Secret wrapper for preflight and supportbundle
- [ ] `kubectl preflight` runs successfully using Secret-wrapped spec
- [ ] `kubectl support-bundle` discovers spec from Secret
- [ ] No false positive on DB/NATS regex with structured logs
- [ ] `helm lint` passes on all value combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)