### PR TITLE
fix: upload support bundle to local SDK + gitignore scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ chart/charts/
 .env.local
 
 # Build artifacts
-api
+/api
 *.tgz
 
 # Kubeconfig

--- a/chart/templates/_supportbundle.tpl
+++ b/chart/templates/_supportbundle.tpl
@@ -98,7 +98,7 @@ spec:
     {{- /* 3.5: Known failure pattern — DB and NATS connection errors */}}
     - textAnalyze:
         checkName: Database and NATS Connection Failures
-        fileName: dronerx/api-logs/*/*
+        fileName: dronerx/api-logs/*/api.log
         regex: '"level":"ERROR".*database|"level":"ERROR".*nats|NATS not connected'
         outcomes:
           - fail:

--- a/chart/templates/_supportbundle.tpl
+++ b/chart/templates/_supportbundle.tpl
@@ -58,7 +58,7 @@ spec:
     {{- /* 3.3: Health endpoint textAnalyze */}}
     - textAnalyze:
         checkName: Application Health Endpoint
-        fileName: dronerx-health/*/dronerx-health-stdout.txt
+        fileName: dronerx-health/*/*/dronerx-health-stdout.txt
         regex: '"status":\s*"ok"'
         outcomes:
           - fail:

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -150,7 +150,7 @@ func main() {
 	trackingHandler := handlers.NewTrackingHandler(nc, sdkClient)
 	licenseHandler := handlers.NewLicenseHandler(sdkClient)
 	updatesHandler := handlers.NewUpdatesHandler(sdkClient)
-	adminHandler := handlers.NewAdminHandler(cfg.Namespace, "support-bundle", nil)
+	adminHandler := handlers.NewAdminHandler(cfg.Namespace, cfg.SDKUrl, "sh", nil)
 
 	// 9. Set up routes
 	mux := http.NewServeMux()

--- a/internal/handlers/admin.go
+++ b/internal/handlers/admin.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os/exec"
@@ -12,23 +13,25 @@ import (
 // AdminHandler handles administrative operations.
 type AdminHandler struct {
 	namespace string
+	sdkURL    string
 	cmdName   string
 	cmdArgs   []string
 }
 
 // NewAdminHandler creates an AdminHandler. The cmdName and cmdArgs parameters
 // allow injecting a mock command for testing. For production use, pass
-// "support-bundle" and nil.
-func NewAdminHandler(namespace string, cmdName string, cmdArgs []string) *AdminHandler {
+// "sh" and nil (the handler builds a shell script that collects and uploads).
+func NewAdminHandler(namespace, sdkURL, cmdName string, cmdArgs []string) *AdminHandler {
 	return &AdminHandler{
 		namespace: namespace,
+		sdkURL:    sdkURL,
 		cmdName:   cmdName,
 		cmdArgs:   cmdArgs,
 	}
 }
 
 // GenerateSupportBundle handles POST /api/admin/support-bundle.
-// It execs the support-bundle CLI to collect and upload diagnostics.
+// It collects a support bundle via the CLI and uploads it to the SDK.
 func (h *AdminHandler) GenerateSupportBundle(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -42,11 +45,15 @@ func (h *AdminHandler) GenerateSupportBundle(w http.ResponseWriter, r *http.Requ
 
 	args := h.cmdArgs
 	if args == nil {
-		args = []string{
-			"--load-cluster-specs",
-			"--auto-upload",
-			"-n", h.namespace,
-		}
+		// Two-step: collect bundle, then upload to local SDK endpoint.
+		// --auto-upload targets replicated.app which requires a license ID.
+		// Instead, we POST the tarball directly to the SDK's upload endpoint.
+		script := fmt.Sprintf(`set -e
+BUNDLE=$(support-bundle --load-cluster-specs -n %s -o /tmp/support-bundle.tar.gz 2>&1 && echo /tmp/support-bundle.tar.gz)
+wget -q --header="Content-Type: application/gzip" --post-file=/tmp/support-bundle.tar.gz -O - %s/api/v1/supportbundle
+rm -f /tmp/support-bundle.tar.gz`,
+			h.namespace, h.sdkURL)
+		args = []string{"-c", script}
 	}
 
 	cmd := exec.CommandContext(ctx, h.cmdName, args...)
@@ -64,7 +71,7 @@ func (h *AdminHandler) GenerateSupportBundle(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	slog.Info("support bundle generated", "output", string(output))
+	slog.Info("support bundle generated and uploaded", "output", string(output))
 	json.NewEncoder(w).Encode(map[string]string{
 		"status":  "ok",
 		"message": "Support bundle generated and uploaded to Vendor Portal",

--- a/internal/handlers/admin_test.go
+++ b/internal/handlers/admin_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAdminHandler_GenerateSupportBundle(t *testing.T) {
 	t.Run("returns ok when command succeeds", func(t *testing.T) {
-		h := NewAdminHandler("default", "echo", []string{"bundle-generated"})
+		h := NewAdminHandler("default", "http://sdk:3000", "echo", []string{"bundle-generated"})
 
 		req := httptest.NewRequest(http.MethodPost, "/api/admin/support-bundle", nil)
 		w := httptest.NewRecorder()
@@ -28,7 +28,7 @@ func TestAdminHandler_GenerateSupportBundle(t *testing.T) {
 	})
 
 	t.Run("returns error when command fails", func(t *testing.T) {
-		h := NewAdminHandler("default", "false", nil)
+		h := NewAdminHandler("default", "http://sdk:3000", "false", nil)
 
 		req := httptest.NewRequest(http.MethodPost, "/api/admin/support-bundle", nil)
 		w := httptest.NewRecorder()
@@ -47,7 +47,7 @@ func TestAdminHandler_GenerateSupportBundle(t *testing.T) {
 	})
 
 	t.Run("rejects non-POST methods", func(t *testing.T) {
-		h := NewAdminHandler("default", "echo", []string{"ok"})
+		h := NewAdminHandler("default", "http://sdk:3000", "echo", []string{"ok"})
 
 		req := httptest.NewRequest(http.MethodGet, "/api/admin/support-bundle", nil)
 		w := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

- Fix support bundle upload to use local SDK endpoint (`/api/v1/supportbundle`) instead of `replicated.app` which requires a license ID
- Fix `.gitignore` — `api` pattern was matching `cmd/api/` paths; scoped to `/api` (root binary only)

## Test Plan

- [ ] Go tests pass (`go test ./internal/handlers/ -run TestAdminHandler`)
- [ ] Deploy to cluster, generate support bundle from `/admin`, verify bundle appears in Vendor Portal
- [ ] `git add cmd/api/main.go` works without `-f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)