### PR TITLE
fix: correct EC Helm extension format for cert-manager

### DIFF
--- a/replicated/embedded-cluster.yaml
+++ b/replicated/embedded-cluster.yaml
@@ -5,15 +5,26 @@ metadata:
 spec:
   version: "3.0.0-alpha-31+k8s-1.34"
   extensions:
-    helmCharts:
-      - chart:
-          name: cert-manager
-          chartVersion: "v1.17.1"
-        releaseName: cert-manager
-        namespace: cert-manager
-        weight: 10
-        values: |
-          crds:
-            enabled: true
-          image:
-            pullPolicy: IfNotPresent
+    helm:
+      repositories:
+        - name: jetstack
+          url: https://charts.jetstack.io
+      charts:
+        - name: cert-manager
+          chartname: jetstack/cert-manager
+          namespace: cert-manager
+          version: "v1.17.1"
+          values: |
+            crds:
+              enabled: true
+            image:
+              digest: ""
+            webhook:
+              image:
+                digest: ""
+            cainjector:
+              image:
+                digest: ""
+            startupapicheck:
+              image:
+                digest: ""


### PR DESCRIPTION
## Summary

- Fix `embedded-cluster.yaml` to use the correct extension format: `extensions.helm.repositories` + `extensions.helm.charts` instead of the incorrect `extensions.helmCharts` schema from the pre-release docs
- Add jetstack repository declaration for cert-manager
- Add `digest: ""` on all cert-manager images for air-gap compatibility

The previous format caused: `failed to install addons: install extensions: get extensions: find chart archive for cert-manager: no chart archive found`

## Test plan

- [ ] EC install succeeds past the addon installation phase
- [ ] cert-manager pods running in cert-manager namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)