### PR TITLE
fix: revert to helmCharts format for EC cert-manager extension

### DIFF
--- a/replicated/embedded-cluster.yaml
+++ b/replicated/embedded-cluster.yaml
@@ -5,26 +5,23 @@ metadata:
 spec:
   version: "3.0.0-alpha-31+k8s-1.34"
   extensions:
-    helm:
-      repositories:
-        - name: jetstack
-          url: https://charts.jetstack.io
-      charts:
-        - name: cert-manager
-          chartname: jetstack/cert-manager
-          namespace: cert-manager
-          version: "v1.17.1"
-          values: |
-            crds:
-              enabled: true
+    helmCharts:
+      - chart:
+          name: cert-manager
+          chartVersion: "v1.17.1"
+        releaseName: cert-manager
+        namespace: cert-manager
+        values: |
+          crds:
+            enabled: true
+          image:
+            digest: ""
+          webhook:
             image:
               digest: ""
-            webhook:
-              image:
-                digest: ""
-            cainjector:
-              image:
-                digest: ""
-            startupapicheck:
-              image:
-                digest: ""
+          cainjector:
+            image:
+              digest: ""
+          startupapicheck:
+            image:
+              digest: ""


### PR DESCRIPTION
## Summary

- Revert from `extensions.helm.repositories` + `extensions.helm.charts` format back to `extensions.helmCharts` with `chart.name` + `chart.chartVersion`
- Use blank `digest: ""` fields instead of `ReplicatedImageName` (which the linter rejects)
- Root cause confirmed by colleague: linter rejects `ReplicatedImageName` in EC config, but the `helmCharts` schema itself is correct

## Test plan

- [ ] EC install succeeds past addon installation phase
- [ ] cert-manager pods running in cert-manager namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)