### PR TITLE
fix: remove cert-manager extension to unblock EC testing

### DIFF
--- a/replicated/embedded-cluster.yaml
+++ b/replicated/embedded-cluster.yaml
@@ -4,24 +4,3 @@ metadata:
   name: drone-rx
 spec:
   version: "3.0.0-alpha-31+k8s-1.34"
-  extensions:
-    helmCharts:
-      - chart:
-          name: cert-manager
-          chartVersion: "v1.17.1"
-        releaseName: cert-manager
-        namespace: cert-manager
-        values: |
-          crds:
-            enabled: true
-          image:
-            digest: ""
-          webhook:
-            image:
-              digest: ""
-          cainjector:
-            image:
-              digest: ""
-          startupapicheck:
-            image:
-              digest: ""

--- a/scripts/dev-release.sh
+++ b/scripts/dev-release.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Create a dev Replicated release for manual testing.
+# Usage: ./scripts/dev-release.sh [channel]
+# Default channel: Unstable
+set -euo pipefail
+
+CHANNEL="${1:-Unstable}"
+VERSION="0.0.0-dev.$(date +%s)"
+
+echo "Creating dev release ${VERSION} on channel ${CHANNEL}..."
+
+# Substitute $VERSION placeholders (same as CI does)
+sed -i.bak "s|tag: \"[^\"]*\" # x-release-please-version|tag: \"${VERSION}\" # x-release-please-version|g" chart/values.yaml
+sed -i.bak "s|^version:.*|version: ${VERSION}|" chart/Chart.yaml
+sed -i.bak "s|^appVersion:.*|appVersion: \"${VERSION}\"|" chart/Chart.yaml
+sed -i.bak "s/\$VERSION/${VERSION}/g" replicated/dronerx-chart.yaml
+
+# Build chart dependencies
+helm repo add cnpg https://cloudnative-pg.github.io/charts 2>/dev/null || true
+helm repo add nats https://nats-io.github.io/k8s/helm/charts 2>/dev/null || true
+helm repo update >/dev/null 2>&1
+
+# Create the release
+replicated release create \
+  --version "${VERSION}" \
+  --promote "${CHANNEL}" \
+  --ensure-channel
+
+echo ""
+echo "Release ${VERSION} created on ${CHANNEL}."
+echo "Reverting local file changes..."
+
+# Revert substitutions
+git checkout chart/values.yaml chart/Chart.yaml replicated/dronerx-chart.yaml
+rm -f chart/values.yaml.bak chart/Chart.yaml.bak replicated/dronerx-chart.yaml.bak
+
+echo "Done. Local files restored."


### PR DESCRIPTION
## Summary

- Remove cert-manager Helm extension from EC config to unblock base EC install testing
- cert-manager will be re-added once the chart archive resolution issue is figured out

## Test plan

- [ ] EC install succeeds without the extension
- [ ] All app pods Running, app accessible via admin console

🤖 Generated with [Claude Code](https://claude.com/claude-code)