### PR TITLE
feat: replace Svelte logo with DroneRx drone icon

### DIFF
--- a/docs/superpowers/plans/2026-04-15-light-mode.md
+++ b/docs/superpowers/plans/2026-04-15-light-mode.md
@@ -1,0 +1,703 @@
+# Light Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a license-gated Light Mode toggle that swaps the dark navy theme to a white/light theme, controlled by a Replicated custom license field.
+
+**Architecture:** The backend exposes a `light_mode_enabled` Boolean via `/api/license/status`, following the existing `live_tracking_enabled` pattern. The frontend reads this flag to conditionally show a sun/moon toggle in the header. CSS variable overrides on `[data-theme="light"]` handle all color swaps without changing component classes.
+
+**Tech Stack:** Go (backend handler + config), Helm (values + ConfigMap), SvelteKit + Tailwind CSS v4 (frontend)
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `internal/config/config.go` | Add `LightModeEnabled` env var |
+| `internal/handlers/license.go` | Add `LightModeEnabled` to API response |
+| `internal/handlers/license_test.go` | **New** — test license handler response |
+| `cmd/api/main.go` | Register `light_mode_enabled` feature override |
+| `chart/values.yaml` | Add `lightModeEnabled: "false"` default |
+| `chart/templates/configmap-api.yaml` | Add `LIGHT_MODE_ENABLED` env var |
+| `frontend/src/lib/types.ts` | Add `light_mode_enabled` to `LicenseStatus` |
+| `frontend/src/lib/stores/theme.ts` | **New** — theme store with localStorage |
+| `frontend/src/lib/components/ThemeToggle.svelte` | **New** — sun/moon toggle component |
+| `frontend/src/app.css` | Add `[data-theme="light"]` variable overrides |
+| `frontend/src/routes/+layout.svelte` | Apply `data-theme` to body, expose license |
+| `frontend/src/routes/+page.svelte` | Add ThemeToggle to header |
+| `frontend/src/routes/order/+page.svelte` | Add ThemeToggle to header |
+| `frontend/src/routes/order/[id]/+page.svelte` | Add ThemeToggle to header |
+| `frontend/src/routes/orders/+page.svelte` | Add ThemeToggle to header |
+| `frontend/src/routes/admin/+page.svelte` | Add ThemeToggle to header |
+
+---
+
+### Task 1: Backend — Config and License Handler
+
+**Files:**
+- Modify: `internal/config/config.go:8-29`
+- Modify: `internal/handlers/license.go:20-51`
+- Modify: `cmd/api/main.go:128-132`
+- Create: `internal/handlers/license_test.go`
+
+- [ ] **Step 1: Add `LightModeEnabled` to config struct and Load()**
+
+In `internal/config/config.go`, add the field to the `Config` struct and the `Load()` function:
+
+```go
+type Config struct {
+	Port                string
+	DatabaseURL         string
+	NATSUrl             string
+	TickerInterval      int
+	WebhookURL          string
+	SDKUrl              string
+	Namespace           string
+	LiveTrackingEnabled string
+	LightModeEnabled    string
+}
+
+func Load() Config {
+	return Config{
+		Port:                getEnv("PORT", "8080"),
+		DatabaseURL:         getEnv("DATABASE_URL", ""),
+		NATSUrl:             getEnv("NATS_URL", "nats://localhost:4222"),
+		TickerInterval:      getEnvInt("TICKER_INTERVAL", 5),
+		WebhookURL:          getEnv("WEBHOOK_URL", ""),
+		SDKUrl:              getEnv("REPLICATED_SDK_URL", "http://drone-rx-sdk:3000"),
+		Namespace:           getEnv("POD_NAMESPACE", "default"),
+		LiveTrackingEnabled: getEnv("LIVE_TRACKING_ENABLED", "true"),
+		LightModeEnabled:    getEnv("LIGHT_MODE_ENABLED", "false"),
+	}
+}
+```
+
+- [ ] **Step 2: Add `LightModeEnabled` to license handler response**
+
+In `internal/handlers/license.go`, add the field to the response struct and populate it:
+
+```go
+type licenseStatusResponse struct {
+	Valid               bool   `json:"valid"`
+	Expired             bool   `json:"expired"`
+	LicenseType         string `json:"license_type"`
+	ExpirationDate      string `json:"expiration_date"`
+	LiveTrackingEnabled bool   `json:"live_tracking_enabled"`
+	LightModeEnabled    bool   `json:"light_mode_enabled"`
+}
+```
+
+In the `Status` method, update the SDK-unavailable fallback (line 35-39) to include `LightModeEnabled: false`, and add the feature check in the success path:
+
+```go
+func (h *LicenseHandler) Status(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	info, err := h.client.GetLicenseInfo()
+	if err != nil {
+		json.NewEncoder(w).Encode(licenseStatusResponse{
+			Valid:               true,
+			Expired:             false,
+			LiveTrackingEnabled: false,
+			LightModeEnabled:    false,
+		})
+		return
+	}
+
+	liveTracking := h.client.IsFeatureEnabled("live_tracking_enabled")
+	lightMode := h.client.IsFeatureEnabled("light_mode_enabled")
+
+	json.NewEncoder(w).Encode(licenseStatusResponse{
+		Valid:               !info.IsExpired(),
+		Expired:             info.IsExpired(),
+		LicenseType:         info.LicenseType,
+		ExpirationDate:      info.ExpirationDate(),
+		LiveTrackingEnabled: liveTracking,
+		LightModeEnabled:    lightMode,
+	})
+}
+```
+
+- [ ] **Step 3: Register feature override in main.go**
+
+In `cmd/api/main.go`, after the existing `live_tracking_enabled` override (line 130-132), add:
+
+```go
+if cfg.LightModeEnabled != "" {
+	sdkClient.SetFeatureOverride("light_mode_enabled", cfg.LightModeEnabled)
+}
+```
+
+- [ ] **Step 4: Write license handler test**
+
+Create `internal/handlers/license_test.go`:
+
+```go
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jwilson/dronerx/internal/handlers"
+	"github.com/jwilson/dronerx/internal/sdk"
+)
+
+func TestLicenseStatus_IncludesLightMode(t *testing.T) {
+	// Mock SDK server that returns license info and light_mode_enabled field
+	sdkSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/license/info":
+			w.Write([]byte(`{
+				"licenseID": "test-123",
+				"channelName": "Stable",
+				"licenseType": "prod",
+				"entitlements": {
+					"expires_at": {"title": "Expiration", "value": "2027-01-01T00:00:00Z", "valueType": "String"}
+				}
+			}`))
+		case "/api/v1/license/fields/live_tracking_enabled":
+			json.NewEncoder(w).Encode(sdk.LicenseField{Name: "live_tracking_enabled", Value: true, ValueType: "Boolean"})
+		case "/api/v1/license/fields/light_mode_enabled":
+			json.NewEncoder(w).Encode(sdk.LicenseField{Name: "light_mode_enabled", Value: true, ValueType: "Boolean"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer sdkSrv.Close()
+
+	client := sdk.NewClient(sdkSrv.URL)
+	handler := handlers.NewLicenseHandler(client)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/license/status", nil)
+	rr := httptest.NewRecorder()
+	handler.Status(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp struct {
+		Valid               bool   `json:"valid"`
+		Expired             bool   `json:"expired"`
+		LicenseType         string `json:"license_type"`
+		LiveTrackingEnabled bool   `json:"live_tracking_enabled"`
+		LightModeEnabled    bool   `json:"light_mode_enabled"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !resp.LightModeEnabled {
+		t.Error("expected light_mode_enabled to be true")
+	}
+	if !resp.LiveTrackingEnabled {
+		t.Error("expected live_tracking_enabled to be true")
+	}
+	if !resp.Valid {
+		t.Error("expected valid to be true")
+	}
+}
+
+func TestLicenseStatus_SDKDown_DefaultsFalse(t *testing.T) {
+	// SDK server that always 500s
+	sdkSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer sdkSrv.Close()
+
+	client := sdk.NewClient(sdkSrv.URL)
+	handler := handlers.NewLicenseHandler(client)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/license/status", nil)
+	rr := httptest.NewRecorder()
+	handler.Status(rr, req)
+
+	var resp struct {
+		LightModeEnabled bool `json:"light_mode_enabled"`
+		Valid            bool `json:"valid"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp.LightModeEnabled {
+		t.Error("expected light_mode_enabled false when SDK down")
+	}
+	if !resp.Valid {
+		t.Error("expected valid true when SDK down (fail open)")
+	}
+}
+```
+
+- [ ] **Step 5: Run backend tests**
+
+Run: `cd /Users/jwilson/git/dronerx && go test ./internal/handlers/ -run TestLicenseStatus -v`
+Expected: Both `TestLicenseStatus_IncludesLightMode` and `TestLicenseStatus_SDKDown_DefaultsFalse` PASS.
+
+- [ ] **Step 6: Commit backend changes**
+
+```bash
+git add internal/config/config.go internal/handlers/license.go internal/handlers/license_test.go cmd/api/main.go
+git commit -m "feat: add light_mode_enabled license field to API"
+```
+
+---
+
+### Task 2: Helm Chart — Values and ConfigMap
+
+**Files:**
+- Modify: `chart/values.yaml:17`
+- Modify: `chart/templates/configmap-api.yaml:13`
+
+- [ ] **Step 1: Add `lightModeEnabled` to values.yaml**
+
+In `chart/values.yaml`, add after line 17 (`liveTrackingEnabled: "true"`):
+
+```yaml
+  lightModeEnabled: "false"
+```
+
+- [ ] **Step 2: Add `LIGHT_MODE_ENABLED` to ConfigMap**
+
+In `chart/templates/configmap-api.yaml`, add after line 13 (`LIVE_TRACKING_ENABLED`):
+
+```yaml
+  LIGHT_MODE_ENABLED: {{ .Values.api.lightModeEnabled | quote }}
+```
+
+- [ ] **Step 3: Lint the chart**
+
+Run: `cd /Users/jwilson/git/dronerx && helm lint chart/`
+Expected: `0 chart(s) failed` — no errors.
+
+- [ ] **Step 4: Commit Helm changes**
+
+```bash
+git add chart/values.yaml chart/templates/configmap-api.yaml
+git commit -m "feat: add light_mode_enabled to Helm chart config"
+```
+
+---
+
+### Task 3: Frontend — Type Update and Theme Store
+
+**Files:**
+- Modify: `frontend/src/lib/types.ts:37-43`
+- Create: `frontend/src/lib/stores/theme.ts`
+
+- [ ] **Step 1: Add `light_mode_enabled` to LicenseStatus type**
+
+In `frontend/src/lib/types.ts`, update the `LicenseStatus` interface:
+
+```typescript
+export interface LicenseStatus {
+	valid: boolean;
+	expired: boolean;
+	license_type?: string;
+	expiration_date?: string;
+	live_tracking_enabled: boolean;
+	light_mode_enabled: boolean;
+}
+```
+
+- [ ] **Step 2: Create theme store**
+
+Create `frontend/src/lib/stores/theme.ts`:
+
+```typescript
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+export type Theme = 'dark' | 'light';
+
+const STORAGE_KEY = 'dronerx-theme';
+
+function getInitialTheme(): Theme {
+	if (browser) {
+		const stored = localStorage.getItem(STORAGE_KEY);
+		if (stored === 'light' || stored === 'dark') return stored;
+	}
+	return 'dark';
+}
+
+function createThemeStore() {
+	const { subscribe, update } = writable<Theme>(getInitialTheme());
+
+	return {
+		subscribe,
+		toggle() {
+			update((current) => {
+				const next: Theme = current === 'dark' ? 'light' : 'dark';
+				if (browser) {
+					localStorage.setItem(STORAGE_KEY, next);
+					document.body.dataset.theme = next;
+				}
+				return next;
+			});
+		},
+		init() {
+			// Apply current theme to body on mount
+			if (browser) {
+				const stored = localStorage.getItem(STORAGE_KEY);
+				const theme = stored === 'light' ? 'light' : 'dark';
+				document.body.dataset.theme = theme;
+			}
+		}
+	};
+}
+
+export const theme = createThemeStore();
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/lib/types.ts frontend/src/lib/stores/theme.ts
+git commit -m "feat: add theme store and light_mode_enabled type"
+```
+
+---
+
+### Task 4: Frontend — CSS Light Theme Overrides
+
+**Files:**
+- Modify: `frontend/src/app.css:36-54` (body and scrollbar), `frontend/src/app.css:106-110` (glass-card)
+
+- [ ] **Step 1: Add `[data-theme="light"]` CSS overrides**
+
+In `frontend/src/app.css`, add the light theme block immediately after the scrollbar styles (after line 54, before the `drone-pulse` keyframes):
+
+```css
+/* Light theme overrides */
+[data-theme="light"] {
+  --color-navy-950: #ffffff;
+  --color-navy-900: #f8fafc;
+  --color-navy-800: #f1f5f9;
+  --color-navy-700: #e2e8f0;
+  --color-navy-600: #cbd5e1;
+  --color-navy-500: #94a3b8;
+  --color-navy-400: #64748b;
+  --color-navy-300: #475569;
+  --color-navy-200: #334155;
+  --color-navy-100: #1e293b;
+  --color-navy-50: #0f172a;
+}
+
+[data-theme="light"] body,
+body[data-theme="light"] {
+  color: #1e293b;
+}
+
+[data-theme="light"] .glass-card {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(248, 250, 252, 0.95));
+  border: 1px solid rgba(226, 232, 240, 0.8);
+}
+
+[data-theme="light"] .glass-card-hover:hover {
+  border-color: rgba(0, 229, 255, 0.4);
+  box-shadow: 0 4px 24px rgba(0, 229, 255, 0.1), 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+[data-theme="light"] ::-webkit-scrollbar-track {
+  background: #f1f5f9;
+}
+
+[data-theme="light"] ::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+}
+
+[data-theme="light"] .grid-bg {
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.15) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.15) 1px, transparent 1px);
+}
+```
+
+- [ ] **Step 2: Verify no build errors**
+
+Run: `cd /Users/jwilson/git/dronerx/frontend && npm run build`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/app.css
+git commit -m "feat: add light theme CSS variable overrides"
+```
+
+---
+
+### Task 5: Frontend — ThemeToggle Component
+
+**Files:**
+- Create: `frontend/src/lib/components/ThemeToggle.svelte`
+
+- [ ] **Step 1: Create the ThemeToggle component**
+
+Create `frontend/src/lib/components/ThemeToggle.svelte`:
+
+```svelte
+<script lang="ts">
+	import { theme } from '$lib/stores/theme';
+</script>
+
+<button
+	onclick={() => theme.toggle()}
+	class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-full border transition-all text-sm
+		{$theme === 'light'
+			? 'bg-amber-glow/10 border-amber-glow/30 text-amber-glow'
+			: 'bg-navy-700/50 border-navy-600 text-navy-300 hover:border-navy-400 hover:text-navy-200'}"
+	aria-label="Toggle {$theme === 'dark' ? 'light' : 'dark'} mode"
+	title="{$theme === 'dark' ? 'Light' : 'Dark'} mode"
+>
+	{#if $theme === 'dark'}
+		<!-- Sun icon -->
+		<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+		</svg>
+	{:else}
+		<!-- Moon icon -->
+		<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+		</svg>
+	{/if}
+</button>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/lib/components/ThemeToggle.svelte
+git commit -m "feat: add ThemeToggle component"
+```
+
+---
+
+### Task 6: Frontend — Layout Integration and Theme Init
+
+**Files:**
+- Modify: `frontend/src/routes/+layout.svelte:1-31`
+
+- [ ] **Step 1: Import theme store and initialize on mount**
+
+In `frontend/src/routes/+layout.svelte`, add the theme import and init call. The `license` state is already fetched here — expose `light_mode_enabled` via a Svelte context so child pages can access it without re-fetching.
+
+Replace the `<script>` block with:
+
+```svelte
+<script lang="ts">
+	import '../app.css';
+	import { onMount, setContext } from 'svelte';
+	import { getUpdates, getLicenseStatus } from '$lib/api';
+	import type { UpdateInfo, LicenseStatus } from '$lib/types';
+	import { theme } from '$lib/stores/theme';
+	import { writable } from 'svelte/store';
+
+	let { children } = $props();
+
+	let latestUpdate = $state<UpdateInfo | null>(null);
+	let license = $state<LicenseStatus | null>(null);
+	let bannerDismissed = $state(false);
+
+	let showUpdateBanner = $derived(latestUpdate !== null && !bannerDismissed);
+	let showLicenseWarning = $derived(license !== null && (license.expired || !license.valid));
+
+	// Expose light_mode_enabled to child pages via context
+	const lightModeEnabled = writable(false);
+	setContext('lightModeEnabled', lightModeEnabled);
+
+	onMount(async () => {
+		theme.init();
+
+		try {
+			const [updates, licenseStatus] = await Promise.all([
+				getUpdates().catch(() => []),
+				getLicenseStatus().catch(() => null),
+			]);
+			if (updates && updates.length > 0) {
+				latestUpdate = updates[0];
+			}
+			if (licenseStatus) {
+				license = licenseStatus;
+				lightModeEnabled.set(licenseStatus.light_mode_enabled ?? false);
+			}
+		} catch {
+			// silent — banners are non-critical
+		}
+	});
+</script>
+```
+
+The rest of the template stays unchanged.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/routes/+layout.svelte
+git commit -m "feat: init theme store and expose light_mode_enabled via context"
+```
+
+---
+
+### Task 7: Frontend — Add ThemeToggle to All Page Headers
+
+**Files:**
+- Modify: `frontend/src/routes/+page.svelte:1-53` (home header)
+- Modify: `frontend/src/routes/order/+page.svelte:1-58` (place order header)
+- Modify: `frontend/src/routes/order/[id]/+page.svelte:1-239` (order tracking header)
+- Modify: `frontend/src/routes/orders/+page.svelte:1-71` (order history header)
+- Modify: `frontend/src/routes/admin/+page.svelte:1-45` (admin header)
+
+- [ ] **Step 1: Add toggle to home page header (`+page.svelte`)**
+
+In `frontend/src/routes/+page.svelte`, add the imports at the top of the `<script>` block (after existing imports):
+
+```typescript
+import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+import { getContext } from 'svelte';
+import type { Writable } from 'svelte/store';
+
+const lightModeEnabled = getContext<Writable<boolean>>('lightModeEnabled');
+```
+
+In the header `<nav>` element (line 30-51), add the toggle after the Cart link's closing `</a>` and before the closing `</nav>`:
+
+```svelte
+			{#if $lightModeEnabled}
+				<span class="text-navy-600">|</span>
+				<ThemeToggle />
+			{/if}
+```
+
+- [ ] **Step 2: Add toggle to place order page header**
+
+In `frontend/src/routes/order/+page.svelte`, add imports at the top of the `<script>` block:
+
+```typescript
+import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+import { getContext } from 'svelte';
+import type { Writable } from 'svelte/store';
+
+const lightModeEnabled = getContext<Writable<boolean>>('lightModeEnabled');
+```
+
+In the header `<div>` (line 45-57), change the closing `</div>` of the header inner container to include the toggle. After line 56 (`<span class="text-navy-200 font-medium">Place Order</span>`), add:
+
+```svelte
+		{#if $lightModeEnabled}
+			<span class="ml-auto text-navy-600">|</span>
+			<ThemeToggle />
+		{/if}
+```
+
+- [ ] **Step 3: Add toggle to order tracking page header**
+
+In `frontend/src/routes/order/[id]/+page.svelte`, add imports at the top of the `<script>` block (after existing imports):
+
+```typescript
+import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+import { getContext } from 'svelte';
+import type { Writable } from 'svelte/store';
+
+const lightModeEnabled = getContext<Writable<boolean>>('lightModeEnabled');
+```
+
+In the header (lines 207-239), add the toggle before the closing `</div>` of the header inner container (before line 238 `</div>`), but after the tracking indicator `{/if}` on line 237:
+
+```svelte
+		{#if $lightModeEnabled}
+			<span class="text-navy-600 {wsConnected || trackingEnabled === false ? '' : 'ml-auto'}">|</span>
+			<ThemeToggle />
+		{/if}
+```
+
+- [ ] **Step 4: Add toggle to order history page header**
+
+In `frontend/src/routes/orders/+page.svelte`, add imports at the top of the `<script>` block:
+
+```typescript
+import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+import { getContext } from 'svelte';
+import type { Writable } from 'svelte/store';
+
+const lightModeEnabled = getContext<Writable<boolean>>('lightModeEnabled');
+```
+
+In the header (lines 57-71), add after line 69 (`<span class="text-navy-200 font-medium">Order History</span>`):
+
+```svelte
+		{#if $lightModeEnabled}
+			<span class="ml-auto text-navy-600">|</span>
+			<ThemeToggle />
+		{/if}
+```
+
+- [ ] **Step 5: Add toggle to admin page header**
+
+In `frontend/src/routes/admin/+page.svelte`, add imports at the top of the `<script>` block:
+
+```typescript
+import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+import { getContext } from 'svelte';
+import type { Writable } from 'svelte/store';
+
+const lightModeEnabled = getContext<Writable<boolean>>('lightModeEnabled');
+```
+
+In the header `<nav>` (lines 39-43), add the toggle after the "Back to Store" link and before the closing `</nav>`:
+
+```svelte
+			{#if $lightModeEnabled}
+				<span class="text-navy-600">|</span>
+				<ThemeToggle />
+			{/if}
+```
+
+- [ ] **Step 6: Verify frontend builds**
+
+Run: `cd /Users/jwilson/git/dronerx/frontend && npm run build`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/routes/+page.svelte frontend/src/routes/order/+page.svelte frontend/src/routes/order/\[id\]/+page.svelte frontend/src/routes/orders/+page.svelte frontend/src/routes/admin/+page.svelte
+git commit -m "feat: add ThemeToggle to all page headers"
+```
+
+---
+
+### Task 8: End-to-End Verification
+
+- [ ] **Step 1: Run all backend tests**
+
+Run: `cd /Users/jwilson/git/dronerx && go test ./... -v`
+Expected: All tests pass, including the new license handler tests.
+
+- [ ] **Step 2: Run frontend build**
+
+Run: `cd /Users/jwilson/git/dronerx/frontend && npm run build`
+Expected: Build succeeds with no errors or warnings.
+
+- [ ] **Step 3: Start the dev server and visually test**
+
+Run: `cd /Users/jwilson/git/dronerx/frontend && npm run dev`
+
+Test checklist:
+- Home page loads in dark mode by default
+- Toggle is NOT visible (no license field set)
+- Manually set `LIGHT_MODE_ENABLED=true` env var or mock the API to return `light_mode_enabled: true`
+- Toggle appears in header after Cart button
+- Clicking toggle switches to light mode (white backgrounds, dark text)
+- Clicking again switches back to dark mode
+- Refresh the page — theme preference persists from localStorage
+- Navigate to other pages — toggle appears in all headers
+- Cyan and amber accents remain visible and readable in light mode
+
+- [ ] **Step 4: Lint the Helm chart**
+
+Run: `cd /Users/jwilson/git/dronerx && helm lint chart/`
+Expected: Lint passes with no errors.

--- a/docs/superpowers/specs/2026-04-15-light-mode-design.md
+++ b/docs/superpowers/specs/2026-04-15-light-mode-design.md
@@ -1,0 +1,136 @@
+# Light Mode — License-Gated Theme Toggle
+
+## Overview
+
+A custom Replicated license field (`light_mode_enabled`, Boolean) unlocks a sun/moon theme toggle in the app header. When toggled, the app swaps from the dark navy theme to a white/light gray theme. The user's preference persists in `localStorage`. Without the license entitlement, the toggle is hidden and the app stays dark.
+
+## Approach
+
+**License-unlocked toggle** — the license field gates visibility of a UI toggle; the user chooses dark or light. This is more interactive than a license-only approach and better demonstrates the Replicated entitlement concept.
+
+**Color strategy: swap backgrounds and text, keep accents.** Navy variables are overridden via a `[data-theme="light"]` CSS selector. Cyan-glow and amber-glow accents remain unchanged — they work well on both dark and light backgrounds.
+
+## License Integration (Backend)
+
+### Custom License Field
+
+- **Field name:** `light_mode_enabled`
+- **Type:** Boolean
+- **Default:** `false`
+- Created in the Replicated vendor portal as a custom license field
+
+### API Changes
+
+**`internal/handlers/license.go`** — Add `LightModeEnabled` to the `licenseStatusResponse` struct:
+
+```go
+type licenseStatusResponse struct {
+    Valid               bool   `json:"valid"`
+    Expired             bool   `json:"expired"`
+    LicenseType         string `json:"license_type"`
+    ExpirationDate      string `json:"expiration_date"`
+    LiveTrackingEnabled bool   `json:"live_tracking_enabled"`
+    LightModeEnabled    bool   `json:"light_mode_enabled"`
+}
+```
+
+Populate it using `h.client.IsFeatureEnabled("light_mode_enabled")` — same pattern as `live_tracking_enabled`.
+
+### Configuration
+
+**`internal/config/config.go`** — Add `LightModeEnabled` env var with default `"false"` for fallback when SDK is unavailable.
+
+**`chart/templates/configmap-api.yaml`** — Add:
+
+```yaml
+LIGHT_MODE_ENABLED: {{ .Values.api.lightModeEnabled | quote }}
+```
+
+**`chart/values.yaml`** — Add under `api`:
+
+```yaml
+lightModeEnabled: "false"
+```
+
+## Frontend — Theme Store
+
+**New file: `frontend/src/lib/stores/theme.ts`**
+
+- Svelte `writable` store holding `"dark"` or `"light"`
+- On init, reads `localStorage` key `dronerx-theme`; defaults to `"dark"`
+- On change, writes to `localStorage` and sets `document.body.dataset.theme`
+
+## Frontend — Toggle Component
+
+**New file: `frontend/src/lib/components/ThemeToggle.svelte`**
+
+- Sun/moon icon pill button
+- **Placement:** Header nav, far right after Cart button, separated by a subtle divider
+- **Visibility:** Only rendered when `license.light_mode_enabled === true`
+- Clicking toggles the theme store between `"dark"` and `"light"`
+
+## Frontend — CSS Theming
+
+**`frontend/src/app.css`** — Add a `[data-theme="light"]` block that overrides the navy CSS custom properties:
+
+| Dark (current) | Variable | Light (override) |
+|---|---|---|
+| `#1a2035` | `--color-navy-950` | `#ffffff` |
+| `#212a42` | `--color-navy-900` | `#f8fafc` |
+| `#2a3450` | `--color-navy-800` | `#f1f5f9` |
+| `#1c274a` | `--color-navy-700` | `#e2e8f0` |
+| `#263362` | `--color-navy-600` | `#cbd5e1` |
+| `#334580` | `--color-navy-500` | `#94a3b8` |
+| `#4a5f9e` | `--color-navy-400` | `#64748b` |
+| `#6b7fbf` | `--color-navy-300` | `#475569` |
+| `#95a5d6` | `--color-navy-200` | `#334155` |
+| `#c2cceb` | `--color-navy-100` | `#1e293b` |
+| `#e8ecf7` | `--color-navy-50` | `#0f172a` |
+
+Additional overrides:
+- Body text color: `#1e293b`
+- `.glass-card`: white/80 background with subtle gray border instead of dark gradient
+- Scrollbar: light gray track and thumb
+
+Cyan-glow (`#00e5ff`) and amber-glow (`#ffab00`) stay unchanged.
+
+## Layout Integration
+
+**`frontend/src/routes/+layout.svelte`** — Import theme store; apply `data-theme` attribute to body on mount and on change. The layout already fetches license status; expose `light_mode_enabled` so pages can pass it to the toggle.
+
+**All page headers** — Each page defines its own `<header>`. The toggle must be added to all 5:
+- `frontend/src/routes/+page.svelte` (home)
+- `frontend/src/routes/order/+page.svelte` (place order)
+- `frontend/src/routes/order/[id]/+page.svelte` (order tracking)
+- `frontend/src/routes/orders/+page.svelte` (order history)
+- `frontend/src/routes/admin/+page.svelte` (admin)
+
+Each header gets the `ThemeToggle` component after the last nav element, conditionally rendered based on the license field.
+
+**`frontend/src/lib/types.ts`** — Add `light_mode_enabled: boolean` to the `LicenseStatus` interface.
+
+## Files Summary
+
+| File | Change |
+|---|---|
+| `internal/handlers/license.go` | Add `LightModeEnabled` to response |
+| `internal/config/config.go` | Add `LightModeEnabled` env var |
+| `chart/templates/configmap-api.yaml` | Add `LIGHT_MODE_ENABLED` |
+| `chart/values.yaml` | Add `lightModeEnabled: "false"` |
+| `frontend/src/lib/types.ts` | Add `light_mode_enabled` to `LicenseStatus` |
+| `frontend/src/lib/stores/theme.ts` | **New** — theme writable store with localStorage |
+| `frontend/src/lib/components/ThemeToggle.svelte` | **New** — sun/moon toggle component |
+| `frontend/src/app.css` | Add `[data-theme="light"]` variable overrides |
+| `frontend/src/routes/+layout.svelte` | Apply data-theme, expose license to pages |
+| `frontend/src/routes/+page.svelte` | Add ThemeToggle to header |
+| `frontend/src/routes/order/+page.svelte` | Add ThemeToggle to header |
+| `frontend/src/routes/order/[id]/+page.svelte` | Add ThemeToggle to header |
+| `frontend/src/routes/orders/+page.svelte` | Add ThemeToggle to header |
+| `frontend/src/routes/admin/+page.svelte` | Add ThemeToggle to header |
+
+## What Doesn't Change
+
+- All page components keep existing Tailwind classes (`bg-navy-950`, `text-navy-200`, etc.) — CSS variable overrides handle the swap
+- Cyan/amber accent colors remain the same
+- Animations remain the same
+- Other pages (order, orders, admin) inherit the theme automatically via CSS variables

--- a/frontend/src/lib/assets/favicon.svg
+++ b/frontend/src/lib/assets/favicon.svg
@@ -1,31 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
-  <title>DroneRx</title>
-  <!-- Sky background circle -->
-  <circle cx="64" cy="64" r="62" fill="#1e40af" stroke="#3b82f6" stroke-width="2"/>
-  <!-- Drone body -->
-  <rect x="52" y="56" width="24" height="16" rx="4" fill="#e2e8f0"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 64 64" fill="none" stroke="#06b6d4" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Background -->
+  <rect width="64" height="64" rx="14" fill="#0f172a" stroke="none"/>
+  <!-- Central body -->
+  <rect x="26" y="26" width="12" height="12" rx="3" fill="#06b6d4" opacity="0.2" stroke="#06b6d4"/>
   <!-- Arms -->
-  <line x1="36" y1="52" x2="56" y2="60" stroke="#94a3b8" stroke-width="3" stroke-linecap="round"/>
-  <line x1="92" y1="52" x2="72" y2="60" stroke="#94a3b8" stroke-width="3" stroke-linecap="round"/>
-  <line x1="36" y1="76" x2="56" y2="68" stroke="#94a3b8" stroke-width="3" stroke-linecap="round"/>
-  <line x1="92" y1="76" x2="72" y2="68" stroke="#94a3b8" stroke-width="3" stroke-linecap="round"/>
+  <line x1="30" y1="28" x2="18" y2="16"/>
+  <line x1="34" y1="28" x2="46" y2="16"/>
+  <line x1="30" y1="36" x2="18" y2="48"/>
+  <line x1="34" y1="36" x2="46" y2="48"/>
   <!-- Rotors -->
-  <ellipse cx="36" cy="52" rx="14" ry="4" fill="#3b82f6" opacity="0.7"/>
-  <ellipse cx="92" cy="52" rx="14" ry="4" fill="#3b82f6" opacity="0.7"/>
-  <ellipse cx="36" cy="76" rx="14" ry="4" fill="#3b82f6" opacity="0.7"/>
-  <ellipse cx="92" cy="76" rx="14" ry="4" fill="#3b82f6" opacity="0.7"/>
-  <!-- Rotor hubs -->
-  <circle cx="36" cy="52" r="3" fill="#f8fafc"/>
-  <circle cx="92" cy="52" r="3" fill="#f8fafc"/>
-  <circle cx="36" cy="76" r="3" fill="#f8fafc"/>
-  <circle cx="92" cy="76" r="3" fill="#f8fafc"/>
-  <!-- Camera/sensor -->
-  <circle cx="64" cy="68" r="3" fill="#0ea5e9"/>
-  <!-- Medical cross on body -->
-  <rect x="61" y="58" width="6" height="12" rx="1" fill="#ef4444"/>
-  <rect x="58" y="61" width="12" height="6" rx="1" fill="#ef4444"/>
-  <!-- Package hanging below -->
-  <line x1="64" y1="72" x2="64" y2="86" stroke="#94a3b8" stroke-width="1.5"/>
-  <rect x="57" y="86" width="14" height="10" rx="2" fill="#f8fafc" stroke="#94a3b8" stroke-width="1"/>
-  <rect x="60" y="88" width="8" height="3" rx="1" fill="#ef4444" opacity="0.6"/>
+  <circle cx="18" cy="16" r="8" fill="#06b6d4" opacity="0.1" stroke="#06b6d4" stroke-width="2"/>
+  <circle cx="46" cy="16" r="8" fill="#06b6d4" opacity="0.1" stroke="#06b6d4" stroke-width="2"/>
+  <circle cx="18" cy="48" r="8" fill="#06b6d4" opacity="0.1" stroke="#06b6d4" stroke-width="2"/>
+  <circle cx="46" cy="48" r="8" fill="#06b6d4" opacity="0.1" stroke="#06b6d4" stroke-width="2"/>
+  <!-- Rotor centers -->
+  <circle cx="18" cy="16" r="2" fill="#06b6d4"/>
+  <circle cx="46" cy="16" r="2" fill="#06b6d4"/>
+  <circle cx="18" cy="48" r="2" fill="#06b6d4"/>
+  <circle cx="46" cy="48" r="2" fill="#06b6d4"/>
 </svg>

--- a/frontend/src/lib/assets/favicon.svg
+++ b/frontend/src/lib/assets/favicon.svg
@@ -1,1 +1,31 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="107" height="128" viewBox="0 0 107 128"><title>svelte-logo</title><path d="M94.157 22.819c-10.4-14.885-30.94-19.297-45.792-9.835L22.282 29.608A29.92 29.92 0 0 0 8.764 49.65a31.5 31.5 0 0 0 3.108 20.231 30 30 0 0 0-4.477 11.183 31.9 31.9 0 0 0 5.448 24.116c10.402 14.887 30.942 19.297 45.791 9.835l26.083-16.624A29.92 29.92 0 0 0 98.235 78.35a31.53 31.53 0 0 0-3.105-20.232 30 30 0 0 0 4.474-11.182 31.88 31.88 0 0 0-5.447-24.116" style="fill:#ff3e00"/><path d="M45.817 106.582a20.72 20.72 0 0 1-22.237-8.243 19.17 19.17 0 0 1-3.277-14.503 18 18 0 0 1 .624-2.435l.49-1.498 1.337.981a33.6 33.6 0 0 0 10.203 5.098l.97.294-.09.968a5.85 5.85 0 0 0 1.052 3.878 6.24 6.24 0 0 0 6.695 2.485 5.8 5.8 0 0 0 1.603-.704L69.27 76.28a5.43 5.43 0 0 0 2.45-3.631 5.8 5.8 0 0 0-.987-4.371 6.24 6.24 0 0 0-6.698-2.487 5.7 5.7 0 0 0-1.6.704l-9.953 6.345a19 19 0 0 1-5.296 2.326 20.72 20.72 0 0 1-22.237-8.243 19.17 19.17 0 0 1-3.277-14.502 17.99 17.99 0 0 1 8.13-12.052l26.081-16.623a19 19 0 0 1 5.3-2.329 20.72 20.72 0 0 1 22.237 8.243 19.17 19.17 0 0 1 3.277 14.503 18 18 0 0 1-.624 2.435l-.49 1.498-1.337-.98a33.6 33.6 0 0 0-10.203-5.1l-.97-.294.09-.968a5.86 5.86 0 0 0-1.052-3.878 6.24 6.24 0 0 0-6.696-2.485 5.8 5.8 0 0 0-1.602.704L37.73 51.72a5.42 5.42 0 0 0-2.449 3.63 5.79 5.79 0 0 0 .986 4.372 6.24 6.24 0 0 0 6.698 2.486 5.8 5.8 0 0 0 1.602-.704l9.952-6.342a19 19 0 0 1 5.295-2.328 20.72 20.72 0 0 1 22.237 8.242 19.17 19.17 0 0 1 3.277 14.503 18 18 0 0 1-8.13 12.053l-26.081 16.622a19 19 0 0 1-5.3 2.328" style="fill:#fff"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <title>DroneRx</title>
+  <!-- Sky background circle -->
+  <circle cx="64" cy="64" r="62" fill="#1e40af" stroke="#3b82f6" stroke-width="2"/>
+  <!-- Drone body -->
+  <rect x="52" y="56" width="24" height="16" rx="4" fill="#e2e8f0"/>
+  <!-- Arms -->
+  <line x1="36" y1="52" x2="56" y2="60" stroke="#94a3b8" stroke-width="3" stroke-linecap="round"/>
+  <line x1="92" y1="52" x2="72" y2="60" stroke="#94a3b8" stroke-width="3" stroke-linecap="round"/>
+  <line x1="36" y1="76" x2="56" y2="68" stroke="#94a3b8" stroke-width="3" stroke-linecap="round"/>
+  <line x1="92" y1="76" x2="72" y2="68" stroke="#94a3b8" stroke-width="3" stroke-linecap="round"/>
+  <!-- Rotors -->
+  <ellipse cx="36" cy="52" rx="14" ry="4" fill="#3b82f6" opacity="0.7"/>
+  <ellipse cx="92" cy="52" rx="14" ry="4" fill="#3b82f6" opacity="0.7"/>
+  <ellipse cx="36" cy="76" rx="14" ry="4" fill="#3b82f6" opacity="0.7"/>
+  <ellipse cx="92" cy="76" rx="14" ry="4" fill="#3b82f6" opacity="0.7"/>
+  <!-- Rotor hubs -->
+  <circle cx="36" cy="52" r="3" fill="#f8fafc"/>
+  <circle cx="92" cy="52" r="3" fill="#f8fafc"/>
+  <circle cx="36" cy="76" r="3" fill="#f8fafc"/>
+  <circle cx="92" cy="76" r="3" fill="#f8fafc"/>
+  <!-- Camera/sensor -->
+  <circle cx="64" cy="68" r="3" fill="#0ea5e9"/>
+  <!-- Medical cross on body -->
+  <rect x="61" y="58" width="6" height="12" rx="1" fill="#ef4444"/>
+  <rect x="58" y="61" width="12" height="6" rx="1" fill="#ef4444"/>
+  <!-- Package hanging below -->
+  <line x1="64" y1="72" x2="64" y2="86" stroke="#94a3b8" stroke-width="1.5"/>
+  <rect x="57" y="86" width="14" height="10" rx="2" fill="#f8fafc" stroke="#94a3b8" stroke-width="1"/>
+  <rect x="60" y="88" width="8" height="3" rx="1" fill="#ef4444" opacity="0.6"/>
+</svg>


### PR DESCRIPTION
## Summary

- Replace the Svelte logo favicon with a custom DroneRx icon
- Quadcopter drone with medical cross + delivery package on blue background
- Used in EC admin console (via kots-app.yaml icon URL) and browser favicon

## Test plan

- [ ] EC admin console shows drone icon instead of Svelte logo
- [ ] Browser favicon updates on frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)