### PR TITLE
feat: license-gated Light Mode theme toggle

### DIFF
--- a/chart/templates/configmap-api.yaml
+++ b/chart/templates/configmap-api.yaml
@@ -11,3 +11,4 @@ data:
   WEBHOOK_URL: {{ .Values.api.webhookURL | quote }}
   REPLICATED_SDK_URL: "http://drone-rx-sdk:3000"
   LIVE_TRACKING_ENABLED: {{ .Values.api.liveTrackingEnabled | quote }}
+  LIGHT_MODE_ENABLED: {{ .Values.api.lightModeEnabled | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -16,6 +16,7 @@ api:
   tickerInterval: 5
   webhookURL: ""
   liveTrackingEnabled: "true"
+  lightModeEnabled: "false"
 
 frontend:
   image:

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -130,6 +130,9 @@ func main() {
 	if cfg.LiveTrackingEnabled != "" {
 		sdkClient.SetFeatureOverride("live_tracking_enabled", cfg.LiveTrackingEnabled)
 	}
+	if cfg.LightModeEnabled != "" {
+		sdkClient.SetFeatureOverride("light_mode_enabled", cfg.LightModeEnabled)
+	}
 
 	// 5. Create stores
 	medicineStore := models.NewMedicineStore(db)

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -53,6 +53,50 @@ body {
   border-radius: 3px;
 }
 
+/* Light theme overrides */
+[data-theme="light"] {
+  --color-navy-950: #ffffff;
+  --color-navy-900: #f8fafc;
+  --color-navy-800: #f1f5f9;
+  --color-navy-700: #e2e8f0;
+  --color-navy-600: #cbd5e1;
+  --color-navy-500: #94a3b8;
+  --color-navy-400: #64748b;
+  --color-navy-300: #475569;
+  --color-navy-200: #334155;
+  --color-navy-100: #1e293b;
+  --color-navy-50: #0f172a;
+}
+
+[data-theme="light"] body,
+body[data-theme="light"] {
+  color: #1e293b;
+}
+
+[data-theme="light"] .glass-card {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(248, 250, 252, 0.95));
+  border: 1px solid rgba(226, 232, 240, 0.8);
+}
+
+[data-theme="light"] .glass-card-hover:hover {
+  border-color: rgba(0, 229, 255, 0.4);
+  box-shadow: 0 4px 24px rgba(0, 229, 255, 0.1), 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+[data-theme="light"] ::-webkit-scrollbar-track {
+  background: #f1f5f9;
+}
+
+[data-theme="light"] ::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+}
+
+[data-theme="light"] .grid-bg {
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.15) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.15) 1px, transparent 1px);
+}
+
 /* Drone pulse animation for in-flight status */
 @keyframes drone-pulse {
   0%, 100% { opacity: 1; }

--- a/frontend/src/lib/components/ThemeToggle.svelte
+++ b/frontend/src/lib/components/ThemeToggle.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { theme } from '$lib/stores/theme';
+</script>
+
+<button
+	onclick={() => theme.toggle()}
+	class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-full border transition-all text-sm
+		{$theme === 'light'
+			? 'bg-amber-glow/10 border-amber-glow/30 text-amber-glow'
+			: 'bg-navy-700/50 border-navy-600 text-navy-300 hover:border-navy-400 hover:text-navy-200'}"
+	aria-label="Toggle {$theme === 'dark' ? 'light' : 'dark'} mode"
+	title="{$theme === 'dark' ? 'Light' : 'Dark'} mode"
+>
+	{#if $theme === 'dark'}
+		<!-- Sun icon -->
+		<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+		</svg>
+	{:else}
+		<!-- Moon icon -->
+		<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+		</svg>
+	{/if}
+</button>

--- a/frontend/src/lib/stores/theme.ts
+++ b/frontend/src/lib/stores/theme.ts
@@ -1,0 +1,42 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+export type Theme = 'dark' | 'light';
+
+const STORAGE_KEY = 'dronerx-theme';
+
+function getInitialTheme(): Theme {
+	if (browser) {
+		const stored = localStorage.getItem(STORAGE_KEY);
+		if (stored === 'light' || stored === 'dark') return stored;
+	}
+	return 'dark';
+}
+
+function createThemeStore() {
+	const { subscribe, update } = writable<Theme>(getInitialTheme());
+
+	return {
+		subscribe,
+		toggle() {
+			update((current) => {
+				const next: Theme = current === 'dark' ? 'light' : 'dark';
+				if (browser) {
+					localStorage.setItem(STORAGE_KEY, next);
+					document.body.dataset.theme = next;
+				}
+				return next;
+			});
+		},
+		init() {
+			// Apply current theme to body on mount
+			if (browser) {
+				const stored = localStorage.getItem(STORAGE_KEY);
+				const theme = stored === 'light' ? 'light' : 'dark';
+				document.body.dataset.theme = theme;
+			}
+		}
+	};
+}
+
+export const theme = createThemeStore();

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -40,6 +40,7 @@ export interface LicenseStatus {
 	license_type?: string;
 	expiration_date?: string;
 	live_tracking_enabled: boolean;
+	light_mode_enabled: boolean;
 }
 
 export interface UpdateInfo {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import '../app.css';
-	import { onMount } from 'svelte';
+	import { onMount, setContext } from 'svelte';
 	import { getUpdates, getLicenseStatus } from '$lib/api';
 	import type { UpdateInfo, LicenseStatus } from '$lib/types';
+	import { theme } from '$lib/stores/theme';
+	import { writable } from 'svelte/store';
 
 	let { children } = $props();
 
@@ -13,7 +15,13 @@
 	let showUpdateBanner = $derived(latestUpdate !== null && !bannerDismissed);
 	let showLicenseWarning = $derived(license !== null && (license.expired || !license.valid));
 
+	// Expose light_mode_enabled to child pages via context
+	const lightModeEnabled = writable(false);
+	setContext('lightModeEnabled', lightModeEnabled);
+
 	onMount(async () => {
+		theme.init();
+
 		try {
 			const [updates, licenseStatus] = await Promise.all([
 				getUpdates().catch(() => []),
@@ -24,6 +32,7 @@
 			}
 			if (licenseStatus) {
 				license = licenseStatus;
+				lightModeEnabled.set(licenseStatus.light_mode_enabled ?? false);
 			}
 		} catch {
 			// silent — banners are non-critical

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -3,6 +3,11 @@
 	import MedicineCard from '$lib/components/MedicineCard.svelte';
 	import DroneIcon from '$lib/components/DroneIcon.svelte';
 	import { cartCount } from '$lib/stores/cart';
+	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+	import { getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+
+	const lightModeEnabled = getContext<Writable<boolean>>('lightModeEnabled');
 
 	let { data }: { data: PageData } = $props();
 
@@ -48,6 +53,10 @@
 					</span>
 				{/if}
 			</a>
+			{#if $lightModeEnabled}
+				<span class="text-navy-600">|</span>
+				<ThemeToggle />
+			{/if}
 		</nav>
 	</div>
 </header>

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import { generateSupportBundle } from '$lib/api';
 	import DroneIcon from '$lib/components/DroneIcon.svelte';
+	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+	import { getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+
+	const lightModeEnabled = getContext<Writable<boolean>>('lightModeEnabled');
 
 	let loading = $state(false);
 	let result = $state<{ status: string; message: string } | null>(null);
@@ -40,6 +45,10 @@
 			<a href="/" class="text-sm font-medium text-navy-200 hover:text-cyan-glow transition-colors">
 				Back to Store
 			</a>
+			{#if $lightModeEnabled}
+				<span class="text-navy-600">|</span>
+				<ThemeToggle />
+			{/if}
 		</nav>
 	</div>
 </header>

--- a/frontend/src/routes/order/+page.svelte
+++ b/frontend/src/routes/order/+page.svelte
@@ -3,6 +3,11 @@
 	import { cart, cartTotal } from '$lib/stores/cart';
 	import { createOrder } from '$lib/api';
 	import DroneIcon from '$lib/components/DroneIcon.svelte';
+	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+	import { getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+
+	const lightModeEnabled = getContext<Writable<boolean>>('lightModeEnabled');
 
 	let patientName = $state('');
 	let address = $state('');
@@ -54,6 +59,10 @@
 		</div>
 		<span class="text-navy-600">/</span>
 		<span class="text-navy-200 font-medium">Place Order</span>
+		{#if $lightModeEnabled}
+			<span class="ml-auto text-navy-600">|</span>
+			<ThemeToggle />
+		{/if}
 	</div>
 </header>
 

--- a/frontend/src/routes/order/[id]/+page.svelte
+++ b/frontend/src/routes/order/[id]/+page.svelte
@@ -6,6 +6,11 @@
 	import { connectTracking, getOrder, getLicenseStatus } from '$lib/api';
 	import StatusTracker from '$lib/components/StatusTracker.svelte';
 	import DroneIcon from '$lib/components/DroneIcon.svelte';
+	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+	import { getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+
+	const lightModeEnabled = getContext<Writable<boolean>>('lightModeEnabled');
 
 	let { data }: { data: PageData } = $props();
 
@@ -234,6 +239,10 @@
 				</svg>
 				Premium
 			</span>
+		{/if}
+		{#if $lightModeEnabled}
+			<span class="text-navy-600 {wsConnected || trackingEnabled === false ? '' : 'ml-auto'}">|</span>
+			<ThemeToggle />
 		{/if}
 	</div>
 </header>

--- a/frontend/src/routes/orders/+page.svelte
+++ b/frontend/src/routes/orders/+page.svelte
@@ -3,6 +3,11 @@
 	import { STATUS_LABELS } from '$lib/types';
 	import { listOrders } from '$lib/api';
 	import DroneIcon from '$lib/components/DroneIcon.svelte';
+	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+	import { getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+
+	const lightModeEnabled = getContext<Writable<boolean>>('lightModeEnabled');
 
 	let searchName = $state('');
 	let orders = $state<Order[]>([]);
@@ -67,6 +72,10 @@
 		</div>
 		<span class="text-navy-600">/</span>
 		<span class="text-navy-200 font-medium">Order History</span>
+		{#if $lightModeEnabled}
+			<span class="ml-auto text-navy-600">|</span>
+			<ThemeToggle />
+		{/if}
 	</div>
 </header>
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	SDKUrl              string
 	Namespace           string
 	LiveTrackingEnabled string
+	LightModeEnabled    string
 }
 
 func Load() Config {
@@ -26,6 +27,7 @@ func Load() Config {
 		SDKUrl:              getEnv("REPLICATED_SDK_URL", "http://drone-rx-sdk:3000"),
 		Namespace:           getEnv("POD_NAMESPACE", "default"),
 		LiveTrackingEnabled: getEnv("LIVE_TRACKING_ENABLED", "true"),
+		LightModeEnabled:    getEnv("LIGHT_MODE_ENABLED", "false"),
 	}
 }
 

--- a/internal/handlers/license.go
+++ b/internal/handlers/license.go
@@ -23,6 +23,7 @@ type licenseStatusResponse struct {
 	LicenseType         string `json:"license_type"`
 	ExpirationDate      string `json:"expiration_date"`
 	LiveTrackingEnabled bool   `json:"live_tracking_enabled"`
+	LightModeEnabled    bool   `json:"light_mode_enabled"`
 }
 
 // Status handles GET /api/license/status.
@@ -36,11 +37,13 @@ func (h *LicenseHandler) Status(w http.ResponseWriter, r *http.Request) {
 			Valid:               true,
 			Expired:             false,
 			LiveTrackingEnabled: false,
+			LightModeEnabled:    false,
 		})
 		return
 	}
 
 	liveTracking := h.client.IsFeatureEnabled("live_tracking_enabled")
+	lightMode := h.client.IsFeatureEnabled("light_mode_enabled")
 
 	json.NewEncoder(w).Encode(licenseStatusResponse{
 		Valid:               !info.IsExpired(),
@@ -48,5 +51,6 @@ func (h *LicenseHandler) Status(w http.ResponseWriter, r *http.Request) {
 		LicenseType:         info.LicenseType,
 		ExpirationDate:      info.ExpirationDate(),
 		LiveTrackingEnabled: liveTracking,
+		LightModeEnabled:    lightMode,
 	})
 }

--- a/internal/handlers/license_test.go
+++ b/internal/handlers/license_test.go
@@ -1,0 +1,94 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jwilson/dronerx/internal/handlers"
+	"github.com/jwilson/dronerx/internal/sdk"
+)
+
+func TestLicenseStatus_IncludesLightMode(t *testing.T) {
+	sdkSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/license/info":
+			w.Write([]byte(`{
+				"licenseID": "test-123",
+				"channelName": "Stable",
+				"licenseType": "prod",
+				"entitlements": {
+					"expires_at": {"title": "Expiration", "value": "2027-01-01T00:00:00Z", "valueType": "String"}
+				}
+			}`))
+		case "/api/v1/license/fields/live_tracking_enabled":
+			json.NewEncoder(w).Encode(sdk.LicenseField{Name: "live_tracking_enabled", Value: true, ValueType: "Boolean"})
+		case "/api/v1/license/fields/light_mode_enabled":
+			json.NewEncoder(w).Encode(sdk.LicenseField{Name: "light_mode_enabled", Value: true, ValueType: "Boolean"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer sdkSrv.Close()
+
+	client := sdk.NewClient(sdkSrv.URL)
+	handler := handlers.NewLicenseHandler(client)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/license/status", nil)
+	rr := httptest.NewRecorder()
+	handler.Status(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp struct {
+		Valid               bool   `json:"valid"`
+		Expired             bool   `json:"expired"`
+		LicenseType         string `json:"license_type"`
+		LiveTrackingEnabled bool   `json:"live_tracking_enabled"`
+		LightModeEnabled    bool   `json:"light_mode_enabled"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !resp.LightModeEnabled {
+		t.Error("expected light_mode_enabled to be true")
+	}
+	if !resp.LiveTrackingEnabled {
+		t.Error("expected live_tracking_enabled to be true")
+	}
+	if !resp.Valid {
+		t.Error("expected valid to be true")
+	}
+}
+
+func TestLicenseStatus_SDKDown_DefaultsFalse(t *testing.T) {
+	sdkSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer sdkSrv.Close()
+
+	client := sdk.NewClient(sdkSrv.URL)
+	handler := handlers.NewLicenseHandler(client)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/license/status", nil)
+	rr := httptest.NewRecorder()
+	handler.Status(rr, req)
+
+	var resp struct {
+		LightModeEnabled bool `json:"light_mode_enabled"`
+		Valid            bool `json:"valid"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp.LightModeEnabled {
+		t.Error("expected light_mode_enabled false when SDK down")
+	}
+	if !resp.Valid {
+		t.Error("expected valid true when SDK down (fail open)")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a `light_mode_enabled` custom Replicated license field that unlocks a sun/moon theme toggle in the app header
- Toggle switches the app from dark navy theme to white/light gray by overriding CSS custom properties via `[data-theme="light"]`
- User's theme preference persists in localStorage; toggle only appears when the license entitlement is active

## Changes
- **Backend**: `light_mode_enabled` added to `/api/license/status` response, config env var, and Helm chart ConfigMap
- **Frontend**: New theme store (`stores/theme.ts`), ThemeToggle component, CSS light overrides in `app.css`, toggle integrated into all 5 page headers via Svelte context
- **Tests**: New license handler tests covering both SDK-available and SDK-down paths

## Test plan
- [ ] Deploy with `light_mode_enabled: false` in license — verify toggle is hidden
- [ ] Enable `light_mode_enabled: true` in license — verify toggle appears after Cart in header
- [ ] Click toggle — backgrounds swap to white, text to dark, cyan/amber accents stay
- [ ] Refresh page — theme preference persists from localStorage
- [ ] Navigate across all pages (home, order, tracking, history, admin) — toggle appears consistently
- [ ] Verify dark mode still works correctly when toggling back

🤖 Generated with [Claude Code](https://claude.com/claude-code)