### PR TITLE
feat: split image fields into registry/repository for EC v3

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -81,7 +81,7 @@ Fails if postgresql is disabled but no external host is provided.
 Called automatically by the dronerx.databaseURL helper.
 */}}
 {{- define "dronerx.validateDatabase" -}}
-{{- if and (not .Values.postgresql.enabled) (not .Values.externalDatabase.host) -}}
+{{- if and (ne .Values.postgresql.enabled true) (not .Values.externalDatabase.host) -}}
   {{- fail "Invalid configuration: postgresql.enabled=false but externalDatabase.host is not set. Either enable embedded postgres or provide an external database host." -}}
 {{- end -}}
 {{- end -}}
@@ -92,7 +92,7 @@ Uses CNPG cluster when postgresql.enabled=true, otherwise external DB.
 */}}
 {{- define "dronerx.databaseURL" -}}
 {{- include "dronerx.validateDatabase" . -}}
-{{- if .Values.postgresql.enabled -}}
+{{- if eq .Values.postgresql.enabled true -}}
 {{/* sslmode=disable is correct for cluster-local CNPG traffic */}}
 {{- printf "postgres://dronerx:$(DB_PASSWORD)@%s-db-rw:5432/dronerx?sslmode=disable" (include "dronerx.fullname" .) -}}
 {{- else -}}

--- a/chart/templates/_preflight.tpl
+++ b/chart/templates/_preflight.tpl
@@ -4,10 +4,10 @@ kind: Preflight
 metadata:
   name: {{ include "dronerx.fullname" . }}-preflight
 spec:
-  {{- if or (not .Values.postgresql.enabled) .Values.ingress.tls.cloudflare.enabled }}
+  {{- if or (ne .Values.postgresql.enabled true) .Values.ingress.tls.cloudflare.enabled }}
   collectors:
     {{- /* 3.1a: External DB connectivity collector (conditional) */}}
-    {{- if not .Values.postgresql.enabled }}
+    {{- if ne .Values.postgresql.enabled true }}
     - run:
         collectorName: dronerx-db-check
         image: images.littleroom.co.nz/anonymous/index.docker.io/library/busybox:1.36
@@ -29,7 +29,7 @@ spec:
   {{- end }}
   analyzers:
     {{- /* 3.1a: External DB connectivity analyzer (conditional) */}}
-    {{- if not .Values.postgresql.enabled }}
+    {{- if ne .Values.postgresql.enabled true }}
     - textAnalyze:
         checkName: External Database Connectivity
         fileName: dronerx-db-check.log

--- a/chart/templates/_supportbundle.tpl
+++ b/chart/templates/_supportbundle.tpl
@@ -24,7 +24,7 @@ spec:
         limits:
           maxLines: 5000
           maxAge: 48h
-    {{- if .Values.postgresql.enabled }}
+    {{- if eq .Values.postgresql.enabled true }}
     - logs:
         name: dronerx/postgres-logs
         selector:

--- a/chart/templates/api-deployment.yaml
+++ b/chart/templates/api-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       imagePullSecrets:
         {{- include "dronerx.imagePullSecrets" . | nindent 8 }}
       serviceAccountName: {{ include "dronerx.fullname" . }}-api
-      {{- if .Values.postgresql.enabled }}
+      {{- if eq .Values.postgresql.enabled true }}
       initContainers:
         - name: wait-for-db
           image: images.littleroom.co.nz/anonymous/index.docker.io/library/busybox:1.36
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
         - name: api
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          image: "{{ .Values.api.image.registry }}/{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           ports:
             - name: http
@@ -45,7 +45,7 @@ spec:
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{- if .Values.postgresql.enabled }}
+                  {{- if eq .Values.postgresql.enabled true }}
                   name: {{ include "dronerx.fullname" . }}-db-app
                   key: password
                   {{- else }}

--- a/chart/templates/db-credentials-secret.yaml
+++ b/chart/templates/db-credentials-secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.postgresql.enabled }}
+{{- if ne .Values.postgresql.enabled true }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/templates/frontend-deployment.yaml
+++ b/chart/templates/frontend-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         {{- include "dronerx.imagePullSecrets" . | nindent 8 }}
       containers:
         - name: frontend
-          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+          image: "{{ .Values.frontend.image.registry }}/{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
           ports:
             - name: http

--- a/chart/templates/postgres-cluster.yaml
+++ b/chart/templates/postgres-cluster.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.postgresql.enabled }}
+{{- if eq .Values.postgresql.enabled true }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/chart/templates/wait-for-cnpg-job.yaml
+++ b/chart/templates/wait-for-cnpg-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.postgresql.enabled }}
+{{- if eq .Values.postgresql.enabled true }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -10,6 +10,10 @@
         "image": {
           "type": "object",
           "properties": {
+            "registry": {
+              "type": "string",
+              "description": "API container image registry"
+            },
             "repository": {
               "type": "string",
               "description": "API container image repository"
@@ -24,7 +28,7 @@
               "description": "Image pull policy"
             }
           },
-          "required": ["repository", "tag"]
+          "required": ["registry", "repository", "tag"]
         },
         "replicas": {
           "type": "integer",
@@ -80,6 +84,10 @@
         "image": {
           "type": "object",
           "properties": {
+            "registry": {
+              "type": "string",
+              "description": "Frontend container image registry"
+            },
             "repository": {
               "type": "string",
               "description": "Frontend container image repository"
@@ -94,7 +102,7 @@
               "description": "Image pull policy"
             }
           },
-          "required": ["repository", "tag"]
+          "required": ["registry", "repository", "tag"]
         },
         "replicas": {
           "type": "integer",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,6 +1,7 @@
 api:
   image:
-    repository: images.littleroom.co.nz/proxy/drone-rx/ghcr.io/jmboby/dronerx-api
+    registry: images.littleroom.co.nz
+    repository: proxy/drone-rx/ghcr.io/jmboby/dronerx-api
     tag: "1.0.0" # x-release-please-version
     pullPolicy: IfNotPresent
   replicas: 1
@@ -18,7 +19,8 @@ api:
 
 frontend:
   image:
-    repository: images.littleroom.co.nz/proxy/drone-rx/ghcr.io/jmboby/dronerx-frontend
+    registry: images.littleroom.co.nz
+    repository: proxy/drone-rx/ghcr.io/jmboby/dronerx-frontend
     tag: "1.0.0" # x-release-please-version
     pullPolicy: IfNotPresent
   replicas: 1

--- a/replicated/dronerx-chart.yaml
+++ b/replicated/dronerx-chart.yaml
@@ -6,14 +6,25 @@ spec:
   chart:
     name: drone-rx
     chartVersion: $VERSION
+  builder:
+    api:
+      image:
+        registry: ghcr.io
+        repository: jmboby/dronerx-api
+    frontend:
+      image:
+        registry: ghcr.io
+        repository: jmboby/dronerx-frontend
   values:
     api:
       image:
+        registry: 'repl{{ ReplicatedImageRegistry "ghcr.io" }}'
         repository: 'repl{{ ReplicatedImageRepository "ghcr.io/jmboby/dronerx-api" }}'
         tag: $VERSION
       liveTrackingEnabled: 'repl{{ LicenseFieldValue "live_tracking_enabled" }}'
     frontend:
       image:
+        registry: 'repl{{ ReplicatedImageRegistry "ghcr.io" }}'
         repository: 'repl{{ ReplicatedImageRepository "ghcr.io/jmboby/dronerx-frontend" }}'
         tag: $VERSION
     ingress:
@@ -35,9 +46,6 @@ spec:
         repository: 'repl{{ ReplicatedImageRepository "ghcr.io/cloudnative-pg/cloudnative-pg" }}'
       imagePullSecrets:
         - name: enterprise-pull-secret
-    replicated:
-      image:
-        registry: 'repl{{ ReplicatedImageRegistry "images.littleroom.co.nz" }}'
     nats:
       nats:
         image:


### PR DESCRIPTION
## Summary

- Split combined `repository` fields into separate `registry`/`repository`/`tag` across values.yaml, schema, and deployment templates
- values.yaml defaults keep proxy domain (`images.littleroom.co.nz`) for Helm CLI installs
- HelmChart CR uses EC v3 template functions (`ReplicatedImageRegistry`, `ReplicatedImageRepository`) to override for EC/air-gap
- Added `builder` key with static upstream image refs for air-gap bundle building
- Fixed boolean truthiness: `{{- if eq .Values.postgresql.enabled true }}` instead of bare `{{- if .Values.postgresql.enabled }}` to handle KOTS string coercion

## Files changed (11)

- `chart/values.yaml` — added `registry` field to api and frontend images
- `chart/values.schema.json` — added `registry` to image schemas
- `chart/templates/api-deployment.yaml` — three-field image construction
- `chart/templates/frontend-deployment.yaml` — three-field image construction
- `chart/templates/_helpers.tpl` — truthiness fix
- `chart/templates/_preflight.tpl` — truthiness fix
- `chart/templates/_supportbundle.tpl` — truthiness fix
- `chart/templates/postgres-cluster.yaml` — truthiness fix
- `chart/templates/wait-for-cnpg-job.yaml` — truthiness fix
- `chart/templates/db-credentials-secret.yaml` — truthiness fix
- `replicated/dronerx-chart.yaml` — template functions + builder key

## Test plan

- [ ] `helm lint chart/` passes
- [ ] `helm template` renders correct `registry/repository:tag` images
- [ ] EC v3 install pulls all images successfully
- [ ] All pods Running on EC v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)