### PR TITLE
fix: remove NATS reloader image override for EC

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -88,7 +88,7 @@ nats:
   global:
     image:
       pullSecretNames: []
-  nats:
+  container:
     image:
       registry: images.littleroom.co.nz/anonymous/index.docker.io
       repository: library/nats
@@ -97,6 +97,7 @@ nats:
       registry: images.littleroom.co.nz/anonymous/index.docker.io
       repository: natsio/nats-server-config-reloader
   natsBox:
-    image:
-      registry: images.littleroom.co.nz/anonymous/index.docker.io
-      repository: natsio/nats-box
+    container:
+      image:
+        registry: images.littleroom.co.nz/anonymous/index.docker.io
+        repository: natsio/nats-box

--- a/replicated/dronerx-chart.yaml
+++ b/replicated/dronerx-chart.yaml
@@ -11,13 +11,16 @@ spec:
       image:
         registry: ghcr.io
         repository: jmboby/dronerx-api
+        tag: $VERSION
     frontend:
       image:
         registry: ghcr.io
         repository: jmboby/dronerx-frontend
+        tag: $VERSION
     cloudnative-pg:
       image:
         repository: ghcr.io/cloudnative-pg/cloudnative-pg
+        tag: "1.29.0"
     nats:
       container:
         image:

--- a/replicated/dronerx-chart.yaml
+++ b/replicated/dronerx-chart.yaml
@@ -63,9 +63,6 @@ spec:
       imagePullSecrets:
         - name: enterprise-pull-secret
     nats:
-      reloader:
-        image:
-          fullImageName: 'repl{{ ReplicatedImageName "index.docker.io/natsio/nats-server-config-reloader:0.21.1" }}'
       global:
         image:
           pullSecretNames:


### PR DESCRIPTION
## Summary

- Remove `fullImageName` override for NATS reloader from HelmChart CR
- `ReplicatedImageName` routes through `/proxy/` (private) but this is a public Docker Hub image needing `/anonymous/` path
- The `values.yaml` default already has the correct `images.littleroom.co.nz/anonymous/index.docker.io/natsio/nats-server-config-reloader` path
- All other NATS images work because they use their defaults — reloader was the only one overridden

## Test plan

- [ ] EC online install: NATS pod 2/2 Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)