### PR TITLE
fix: revert EC template functions to hardcoded proxy paths

### DIFF
--- a/replicated/dronerx-chart.yaml
+++ b/replicated/dronerx-chart.yaml
@@ -37,14 +37,14 @@ spec:
   values:
     api:
       image:
-        registry: 'repl{{ ReplicatedImageRegistry "ghcr.io" }}'
-        repository: 'repl{{ ReplicatedImageRepository "ghcr.io/jmboby/dronerx-api" }}'
+        registry: images.littleroom.co.nz
+        repository: proxy/drone-rx/ghcr.io/jmboby/dronerx-api
         tag: $VERSION
       liveTrackingEnabled: 'repl{{ LicenseFieldValue "live_tracking_enabled" }}'
     frontend:
       image:
-        registry: 'repl{{ ReplicatedImageRegistry "ghcr.io" }}'
-        repository: 'repl{{ ReplicatedImageRepository "ghcr.io/jmboby/dronerx-frontend" }}'
+        registry: images.littleroom.co.nz
+        repository: proxy/drone-rx/ghcr.io/jmboby/dronerx-frontend
         tag: $VERSION
     ingress:
       enabled: false
@@ -62,7 +62,7 @@ spec:
       sslmode: repl{{ ConfigOption "external_db_sslmode" }}
     cloudnative-pg:
       image:
-        repository: 'repl{{ ReplicatedImageRegistry "ghcr.io" }}/repl{{ ReplicatedImageRepository "ghcr.io/cloudnative-pg/cloudnative-pg" }}'
+        repository: images.littleroom.co.nz/anonymous/ghcr.io/cloudnative-pg/cloudnative-pg
       imagePullSecrets:
         - name: enterprise-pull-secret
     nats:


### PR DESCRIPTION
## Summary

- Replace `ReplicatedImageRegistry`/`ReplicatedImageRepository` with hardcoded `images.littleroom.co.nz` proxy paths
- These EC v3 template functions work at EC runtime but aren't recognized by the KOTS linter/builder, causing air-gap build failures
- Hardcoded paths work for online EC installs (with `proxyRegistryDomain` in EC config)
- Air-gap support will use the new template functions once linter support lands (new docs expected this week)
- `LicenseFieldValue` and `ConfigOption` functions kept — those are KOTS-native and lint fine

## Lint result

```
RULE                    TYPE     FILENAME    LINE    MESSAGE
helm-archive-missing    error                        Could not find helm archive for chart 'drone-rx' version '$VERSION'
```
Only the expected `$VERSION` placeholder error (CI substitutes it).

## Test plan

- [ ] Air-gap build succeeds on Vendor Portal
- [ ] EC online install still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)