### PR TITLE
fix: restructure builder key for air-gap image discovery

### DIFF
--- a/replicated/dronerx-chart.yaml
+++ b/replicated/dronerx-chart.yaml
@@ -17,23 +17,30 @@ spec:
         registry: ghcr.io
         repository: jmboby/dronerx-frontend
         tag: $VERSION
+    postgresql:
+      enabled: true
+    nats:
+      enabled: true
+      container:
+        image:
+          registry: index.docker.io
+          repository: library/nats
+      reloader:
+        image:
+          registry: index.docker.io
+          repository: natsio/nats-server-config-reloader
+      natsBox:
+        container:
+          image:
+            registry: index.docker.io
+            repository: natsio/nats-box
     cloudnative-pg:
       image:
         repository: ghcr.io/cloudnative-pg/cloudnative-pg
-        tag: "1.29.0"
-    nats:
-      container:
-        image:
-          repository: index.docker.io/library/nats
-          tag: 2.12.6-alpine
-      reloader:
-        image:
-          repository: index.docker.io/natsio/nats-server-config-reloader
-          tag: "0.21.1"
-      natsBox:
-        image:
-          repository: index.docker.io/natsio/nats-box
-          tag: "0.19.3"
+    replicated:
+      image:
+        registry: registry.replicated.com
+        repository: library/replicated-sdk-image
   values:
     api:
       image:


### PR DESCRIPTION
## Summary

The builder key is rendered via `helm template` by the Vendor Portal to discover images for air-gap bundles. The previous structure was a flat list of image overrides — but it needs to match the `values.yaml` structure so the chart templates render correctly and all images are discovered.

Changes:
- Add `postgresql.enabled: true` and `nats.enabled: true` so conditional templates render
- Use upstream registries (`ghcr.io`, `index.docker.io`) not proxy paths
- Fix NATS key names to match subchart (`container.image`, `natsBox.container.image`)
- Add Replicated SDK image
- Remove hardcoded tags from subcharts (chart provides defaults)

## Test plan

- [ ] Air-gap build succeeds on Vendor Portal
- [ ] Online EC install still works (builder key doesn't affect online)

🤖 Generated with [Claude Code](https://claude.com/claude-code)