### PR TITLE
feat: add air-gap image rewriting with HasLocalRegistry

### DIFF
--- a/replicated/dronerx-chart.yaml
+++ b/replicated/dronerx-chart.yaml
@@ -44,14 +44,14 @@ spec:
   values:
     api:
       image:
-        registry: images.littleroom.co.nz
-        repository: proxy/drone-rx/ghcr.io/jmboby/dronerx-api
+        registry: 'repl{{ HasLocalRegistry | ternary LocalRegistryHost "images.littleroom.co.nz" }}'
+        repository: 'repl{{ HasLocalRegistry | ternary (print LocalRegistryNamespace "/dronerx-api") "proxy/drone-rx/ghcr.io/jmboby/dronerx-api" }}'
         tag: $VERSION
       liveTrackingEnabled: 'repl{{ LicenseFieldValue "live_tracking_enabled" }}'
     frontend:
       image:
-        registry: images.littleroom.co.nz
-        repository: proxy/drone-rx/ghcr.io/jmboby/dronerx-frontend
+        registry: 'repl{{ HasLocalRegistry | ternary LocalRegistryHost "images.littleroom.co.nz" }}'
+        repository: 'repl{{ HasLocalRegistry | ternary (print LocalRegistryNamespace "/dronerx-frontend") "proxy/drone-rx/ghcr.io/jmboby/dronerx-frontend" }}'
         tag: $VERSION
     ingress:
       enabled: false
@@ -69,10 +69,26 @@ spec:
       sslmode: repl{{ ConfigOption "external_db_sslmode" }}
     cloudnative-pg:
       image:
-        repository: images.littleroom.co.nz/anonymous/ghcr.io/cloudnative-pg/cloudnative-pg
+        repository: repl{{ HasLocalRegistry | ternary (print LocalRegistryHost "/" LocalRegistryNamespace "/cloudnative-pg") "images.littleroom.co.nz/anonymous/ghcr.io/cloudnative-pg/cloudnative-pg" }}
       imagePullSecrets:
         - name: enterprise-pull-secret
+    replicated:
+      image:
+        registry: 'repl{{ HasLocalRegistry | ternary LocalRegistryHost "images.littleroom.co.nz" }}'
     nats:
+      container:
+        image:
+          registry: 'repl{{ HasLocalRegistry | ternary LocalRegistryHost "images.littleroom.co.nz/anonymous/index.docker.io" }}'
+          repository: 'repl{{ HasLocalRegistry | ternary (print LocalRegistryNamespace "/nats") "library/nats" }}'
+      reloader:
+        image:
+          registry: 'repl{{ HasLocalRegistry | ternary LocalRegistryHost "images.littleroom.co.nz/anonymous/index.docker.io" }}'
+          repository: 'repl{{ HasLocalRegistry | ternary (print LocalRegistryNamespace "/nats-server-config-reloader") "natsio/nats-server-config-reloader" }}'
+      natsBox:
+        container:
+          image:
+            registry: 'repl{{ HasLocalRegistry | ternary LocalRegistryHost "images.littleroom.co.nz/anonymous/index.docker.io" }}'
+            repository: 'repl{{ HasLocalRegistry | ternary (print LocalRegistryNamespace "/nats-box") "natsio/nats-box" }}'
       global:
         image:
           pullSecretNames:


### PR DESCRIPTION
## Summary

Add `HasLocalRegistry`/`LocalRegistryHost`/`LocalRegistryNamespace` ternary patterns to all image references in the HelmChart CR. This makes images pull from the local EC registry in air-gap installs while keeping the custom proxy domain for online installs.

| Install mode | HasLocalRegistry | Image source |
|---|---|---|
| Helm CLI | N/A (uses values.yaml) | `images.littleroom.co.nz` |
| EC online | `false` | `images.littleroom.co.nz` |
| EC air-gap | `true` | `10.244.x.x:5000` (local registry) |

Images covered:
- App images (api, frontend) — split registry/repository
- CNPG operator — combined repository (Pattern 2)
- NATS (container, reloader, nats-box) — split registry/repository
- Replicated SDK — registry override

Builder key unchanged — static upstream paths for air-gap bundle image discovery.

Linter passes (`HasLocalRegistry`, `LocalRegistryHost`, `LocalRegistryNamespace` are supported KOTS functions).

## Test plan

- [ ] EC online install: images pull from `images.littleroom.co.nz` (unchanged)
- [ ] EC air-gap install (CMX with air-gap policy): images pull from local registry
- [ ] Helm CLI install: images pull from `images.littleroom.co.nz` (values.yaml defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)