### PR TITLE
feat: separate CNPG operator into weighted HelmChart CR

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   - name: cloudnative-pg
     version: "0.28.0"
     repository: "https://cloudnative-pg.github.io/charts"
-    condition: postgresql.enabled
+    condition: cnpgOperator.managed
   - name: nats
     version: "2.12.6"
     repository: "https://nats-io.github.io/k8s/helm/charts"

--- a/chart/templates/postgres-cluster.yaml
+++ b/chart/templates/postgres-cluster.yaml
@@ -5,9 +5,11 @@ metadata:
   name: {{ include "dronerx.fullname" . }}-db
   labels:
     {{- include "dronerx.labels" . | nindent 4 }}
+  {{- if .Values.cnpgOperator.managed }}
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "10"
+  {{- end }}
 spec:
   imageName: images.littleroom.co.nz/anonymous/ghcr.io/cloudnative-pg/postgresql:18.3-system-trixie
   instances: {{ .Values.postgresql.instances }}

--- a/chart/templates/wait-for-cnpg-job.yaml
+++ b/chart/templates/wait-for-cnpg-job.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.postgresql.enabled true }}
+{{- if and (eq .Values.postgresql.enabled true) .Values.cnpgOperator.managed }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -54,6 +54,12 @@ cloudnative-pg:
     repository: images.littleroom.co.nz/anonymous/ghcr.io/cloudnative-pg/cloudnative-pg
   imagePullSecrets: []
 
+# -- CNPG operator management mode.
+# true = operator deployed as subchart (helm CLI installs)
+# false = operator deployed externally via Replicated HelmChart CR
+cnpgOperator:
+  managed: true
+
 # -- Embedded PostgreSQL (CloudNativePG).
 # Set postgresql.enabled=false and configure externalDatabase to use BYO Postgres.
 # This toggle controls both the CNPG operator subchart and the Cluster CR.

--- a/replicated/cnpg-operator-chart.yaml
+++ b/replicated/cnpg-operator-chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: cnpg-operator
+spec:
+  chart:
+    name: cloudnative-pg
+    chartVersion: 0.28.0
+  weight: 5
+  helmUpgradeFlags:
+    - --wait
+    - --timeout=5m
+  builder:
+    cloudnative-pg:
+      image:
+        repository: ghcr.io/cloudnative-pg/cloudnative-pg
+        tag: "1.29.0"
+  values:
+    image:
+      repository: 'repl{{ ReplicatedImageRegistry "ghcr.io" }}/repl{{ ReplicatedImageRepository "ghcr.io/cloudnative-pg/cloudnative-pg" }}'
+    imagePullSecrets:
+      - name: enterprise-pull-secret

--- a/replicated/dronerx-chart.yaml
+++ b/replicated/dronerx-chart.yaml
@@ -6,6 +6,7 @@ spec:
   chart:
     name: drone-rx
     chartVersion: $VERSION
+  weight: 10
   builder:
     api:
       image:
@@ -34,14 +35,13 @@ spec:
           image:
             registry: index.docker.io
             repository: natsio/nats-box
-    cloudnative-pg:
-      image:
-        repository: ghcr.io/cloudnative-pg/cloudnative-pg
     replicated:
       image:
         registry: registry.replicated.com
         repository: library/replicated-sdk-image
   values:
+    cnpgOperator:
+      managed: false
     api:
       image:
         registry: 'repl{{ HasLocalRegistry | ternary LocalRegistryHost "images.littleroom.co.nz" }}'
@@ -67,11 +67,6 @@ spec:
       user: repl{{ ConfigOption "external_db_user" }}
       password: repl{{ ConfigOption "external_db_password" }}
       sslmode: repl{{ ConfigOption "external_db_sslmode" }}
-    cloudnative-pg:
-      image:
-        repository: repl{{ HasLocalRegistry | ternary (print LocalRegistryHost "/" LocalRegistryNamespace "/cloudnative-pg") "images.littleroom.co.nz/anonymous/ghcr.io/cloudnative-pg/cloudnative-pg" }}
-      imagePullSecrets:
-        - name: enterprise-pull-secret
     replicated:
       image:
         registry: 'repl{{ HasLocalRegistry | ternary LocalRegistryHost "images.littleroom.co.nz" }}'


### PR DESCRIPTION
## Summary
- Fixes CNPG Cluster CR not being created on EC v3 due to webhook timing issues during bootstrap
- Splits the CNPG operator into a separate Replicated HelmChart CR at weight 5 with `--wait`, ensuring it's fully running before the app chart deploys at weight 10
- Adds `cnpgOperator.managed` toggle to support both install paths: Replicated/EC (managed=false, operator as separate HelmChart CR) and direct Helm CLI (managed=true, operator as subchart with post-install hooks)

## Changes
- `chart/values.yaml` — new `cnpgOperator.managed: true` default
- `chart/Chart.yaml` — CNPG subchart condition changed to `cnpgOperator.managed`
- `chart/templates/postgres-cluster.yaml` — hook annotations conditional on managed flag
- `chart/templates/wait-for-cnpg-job.yaml` — only rendered when managed=true
- `replicated/cnpg-operator-chart.yaml` — **new** HelmChart CR, weight 5, --wait
- `replicated/dronerx-chart.yaml` — weight 10, cnpgOperator.managed=false, CNPG values/builder removed

## Test plan
- [ ] `helm lint chart/` passes with managed=true (default)
- [ ] `helm lint chart/ --set cnpgOperator.managed=false` passes
- [ ] `helm template` with managed=true shows hooks + wait job (Helm CLI path)
- [ ] `helm template` with managed=false shows Cluster CR as regular template, no hooks/wait job (Replicated path)
- [ ] Deploy on EC v3 — verify CNPG operator starts first (weight 5), then app chart (weight 10), Cluster CR created, database starts
- [ ] Direct `helm install` still works with existing hook chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)