### PR TITLE
fix: make PostgreSQL image air-gap aware

### DIFF
--- a/chart/templates/_preflight.tpl
+++ b/chart/templates/_preflight.tpl
@@ -10,7 +10,7 @@ spec:
     {{- if ne .Values.postgresql.enabled true }}
     - run:
         collectorName: dronerx-db-check
-        image: images.littleroom.co.nz/anonymous/index.docker.io/library/busybox:1.36
+        image: {{ .Values.busybox.image }}
         command: ["sh", "-c"]
         args:
           - |
@@ -20,7 +20,7 @@ spec:
     {{- if .Values.ingress.tls.cloudflare.enabled }}
     - run:
         collectorName: dronerx-cloudflare-check
-        image: images.littleroom.co.nz/anonymous/index.docker.io/library/busybox:1.36
+        image: {{ .Values.busybox.image }}
         command: ["sh", "-c"]
         args:
           - |

--- a/chart/templates/api-deployment.yaml
+++ b/chart/templates/api-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       {{- if eq .Values.postgresql.enabled true }}
       initContainers:
         - name: wait-for-db
-          image: images.littleroom.co.nz/anonymous/index.docker.io/library/busybox:1.36
+          image: {{ .Values.busybox.image }}
           command:
             - sh
             - -c

--- a/chart/templates/postgres-cluster.yaml
+++ b/chart/templates/postgres-cluster.yaml
@@ -11,7 +11,7 @@ metadata:
     "helm.sh/hook-weight": "10"
   {{- end }}
 spec:
-  imageName: images.littleroom.co.nz/anonymous/ghcr.io/cloudnative-pg/postgresql:18.3-system-trixie
+  imageName: {{ .Values.postgresql.imageName }}
   instances: {{ .Values.postgresql.instances }}
   bootstrap:
     initdb:

--- a/chart/templates/wait-for-cnpg-job.yaml
+++ b/chart/templates/wait-for-cnpg-job.yaml
@@ -18,7 +18,7 @@ spec:
         {{- include "dronerx.imagePullSecrets" . | nindent 8 }}
       containers:
         - name: wait
-          image: images.littleroom.co.nz/anonymous/index.docker.io/library/busybox:1.36
+          image: {{ .Values.busybox.image }}
           command:
             - sh
             - -c

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -65,6 +65,7 @@ cnpgOperator:
 # This toggle controls both the CNPG operator subchart and the Cluster CR.
 postgresql:
   enabled: true
+  imageName: images.littleroom.co.nz/anonymous/ghcr.io/cloudnative-pg/postgresql:18.3-system-trixie
   instances: 1
   storage:
     size: 1Gi

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -82,6 +82,9 @@ externalDatabase:
   password: ""
   sslmode: "require"
 
+busybox:
+  image: images.littleroom.co.nz/anonymous/index.docker.io/library/busybox:1.36
+
 imagePullSecrets: []
 
 replicated:

--- a/replicated/dronerx-chart.yaml
+++ b/replicated/dronerx-chart.yaml
@@ -20,6 +20,7 @@ spec:
         tag: $VERSION
     postgresql:
       enabled: true
+      imageName: ghcr.io/cloudnative-pg/postgresql:18.3-system-trixie
     nats:
       enabled: true
       container:
@@ -59,6 +60,7 @@ spec:
         mode: "self-signed"
     postgresql:
       enabled: repl{{ ConfigOptionEquals "database_type" "embedded" }}
+      imageName: repl{{ HasLocalRegistry | ternary (print LocalRegistryHost "/" LocalRegistryNamespace "/postgresql:18.3-system-trixie") "images.littleroom.co.nz/anonymous/ghcr.io/cloudnative-pg/postgresql:18.3-system-trixie" }}
       instances: repl{{ ConfigOption "postgres_instances" | ParseInt }}
     externalDatabase:
       host: repl{{ ConfigOption "external_db_host" }}

--- a/replicated/dronerx-chart.yaml
+++ b/replicated/dronerx-chart.yaml
@@ -36,6 +36,8 @@ spec:
           image:
             registry: index.docker.io
             repository: natsio/nats-box
+    busybox:
+      image: index.docker.io/library/busybox:1.36
     replicated:
       image:
         registry: registry.replicated.com
@@ -43,6 +45,8 @@ spec:
   values:
     cnpgOperator:
       managed: false
+    busybox:
+      image: repl{{ HasLocalRegistry | ternary (print LocalRegistryHost "/" LocalRegistryNamespace "/busybox:1.36") "images.littleroom.co.nz/anonymous/index.docker.io/library/busybox:1.36" }}
     api:
       image:
         registry: 'repl{{ HasLocalRegistry | ternary LocalRegistryHost "images.littleroom.co.nz" }}'


### PR DESCRIPTION
## Summary
- CNPG Cluster CR `imageName` was hardcoded to the proxy registry path, which fails in air-gap installs (no outbound access)
- Now driven by `postgresql.imageName` value with `HasLocalRegistry` ternary in the HelmChart CR
- PostgreSQL image added to builder section for air-gap bundling

## Changes
- `chart/values.yaml` — added `postgresql.imageName` with default proxy path
- `chart/templates/postgres-cluster.yaml` — template uses `{{ .Values.postgresql.imageName }}`
- `replicated/dronerx-chart.yaml` — builder declares image, values override with `HasLocalRegistry`

## Test plan
- [ ] Online install: PostgreSQL image pulls from proxy registry
- [ ] Air-gap install: PostgreSQL image pulls from local registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)