### PR TITLE
feat: add Traefik ingress controller for EC v3

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -94,12 +94,14 @@ jobs:
         run: |
           helm repo add cnpg https://cloudnative-pg.github.io/charts
           helm repo add nats https://nats-io.github.io/k8s/helm/charts
+          helm repo add traefik https://traefik.github.io/charts
           helm repo update
 
-      - name: Pull CNPG operator chart for release bundling
+      - name: Pull dependency charts for release bundling
         run: |
-          mkdir -p charts/cnpg-operator
+          mkdir -p charts/cnpg-operator charts/traefik
           helm pull cnpg/cloudnative-pg --version 0.28.0 --untar --untardir charts/cnpg-operator
+          helm pull traefik/traefik --version 39.0.7 --untar --untardir charts/traefik
 
       - name: Set image tags and chart version
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,12 +84,14 @@ jobs:
         run: |
           helm repo add cnpg https://cloudnative-pg.github.io/charts
           helm repo add nats https://nats-io.github.io/k8s/helm/charts
+          helm repo add traefik https://traefik.github.io/charts
           helm repo update
 
-      - name: Pull CNPG operator chart for release bundling
+      - name: Pull dependency charts for release bundling
         run: |
-          mkdir -p charts/cnpg-operator
+          mkdir -p charts/cnpg-operator charts/traefik
           helm pull cnpg/cloudnative-pg --version 0.28.0 --untar --untardir charts/cnpg-operator
+          helm pull traefik/traefik --version 39.0.7 --untar --untardir charts/traefik
 
       - name: Set image tags and chart version
         run: |

--- a/.replicated
+++ b/.replicated
@@ -2,5 +2,6 @@ appSlug: "drone-rx"
 charts:
   - path: ./chart
   - path: ./charts/cnpg-operator/cloudnative-pg
+  - path: ./charts/traefik
 manifests:
   - ./replicated/*.yaml

--- a/replicated/traefik-chart.yaml
+++ b/replicated/traefik-chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: traefik
+spec:
+  chart:
+    name: traefik
+    chartVersion: 39.0.7
+  weight: 3
+  helmUpgradeFlags:
+    - --wait
+    - --timeout=5m
+  builder:
+    image:
+      registry: docker.io
+      repository: traefik
+      tag: v3.6.12
+  values:
+    image:
+      registry: 'repl{{ HasLocalRegistry | ternary LocalRegistryHost "images.littleroom.co.nz/anonymous/index.docker.io" }}'
+      repository: 'repl{{ HasLocalRegistry | ternary (print LocalRegistryNamespace "/traefik") "library/traefik" }}'
+    service:
+      type: NodePort
+      nodePorts:
+        http: 80
+        https: 443
+    imagePullSecrets:
+      - name: enterprise-pull-secret

--- a/scripts/dev-release.sh
+++ b/scripts/dev-release.sh
@@ -23,11 +23,14 @@ sed -i.bak "s|tag: ${VERSION}|tag: latest|g" replicated/dronerx-chart.yaml
 # Build chart dependencies
 helm repo add cnpg https://cloudnative-pg.github.io/charts 2>/dev/null || true
 helm repo add nats https://nats-io.github.io/k8s/helm/charts 2>/dev/null || true
+helm repo add traefik https://traefik.github.io/charts 2>/dev/null || true
 helm repo update >/dev/null 2>&1
+helm dependency build chart/
 
-# Pull CNPG operator chart for release bundling
-mkdir -p charts/cnpg-operator
+# Pull dependency charts for release bundling
+mkdir -p charts/cnpg-operator charts/traefik
 helm pull cnpg/cloudnative-pg --version 0.28.0 --untar --untardir charts/cnpg-operator
+helm pull traefik/traefik --version 39.0.7 --untar --untardir charts/traefik
 
 # Create the release
 replicated release create \
@@ -42,6 +45,6 @@ echo "Reverting local file changes..."
 # Revert substitutions
 git checkout chart/values.yaml chart/Chart.yaml replicated/dronerx-chart.yaml
 rm -f chart/values.yaml.bak chart/Chart.yaml.bak replicated/dronerx-chart.yaml.bak
-rm -rf charts/
+rm -rf chart/charts/ charts/
 
 echo "Done. Local files restored."


### PR DESCRIPTION
## Summary

EC v3 doesn't include an ingress controller. Add Traefik as a separate HelmChart CR at weight 3 so it installs before CNPG (5) and the app (10).

Install order:
1. **Weight 3**: Traefik (ingress controller, `--wait --timeout=5m`)
2. **Weight 5**: CNPG operator (`--wait --timeout=5m`)
3. **Weight 10**: DroneRx app

Config:
- NodePort service type with ports 80/443
- Air-gap image rewriting via `HasLocalRegistry` ternary
- Builder key with upstream Docker Hub image for air-gap bundling
- CI workflows pull `traefik/traefik:39.0.7` alongside CNPG chart

## Test plan

- [ ] EC online install: Traefik pods Running before app deploys
- [ ] Ingress routes work on EC
- [ ] `./scripts/dev-release.sh` includes Traefik chart
- [ ] Air-gap build includes Traefik image

🤖 Generated with [Claude Code](https://claude.com/claude-code)