### PR TITLE
Fix(preflight-v1beta3): Remove unsupported KOTS template functions

### DIFF
--- a/replicated/preflight-v1beta3.yaml
+++ b/replicated/preflight-v1beta3.yaml
@@ -3,57 +3,7 @@ kind: Preflight
 metadata:
   name: drone-rx
 spec:
-  collectors:
-    # External DB connectivity (only when database_type=external)
-    - run:
-        collectorName: dronerx-db-check
-        exclude: 'repl{{ ConfigOptionNotEquals "database_type" "external" }}'
-        image: 'repl{{ ReplicatedImageName "images.littleroom.co.nz/proxy/drone-rx/index.docker.io/library/busybox:1.36" }}'
-        command: ["sh", "-c"]
-        args:
-          - |
-            nc -zv repl{{ ConfigOption "external_db_host" }} repl{{ ConfigOption "external_db_port" }} 2>&1 && echo "connected" || echo "connection_failed"
-    # Cloudflare API connectivity (only when tls_mode=cloudflare AND not airgap)
-    - run:
-        collectorName: dronerx-cloudflare-check
-        exclude: 'repl{{ or (ConfigOptionNotEquals "tls_mode" "cloudflare") IsAirgap }}'
-        image: 'repl{{ ReplicatedImageName "images.littleroom.co.nz/proxy/drone-rx/index.docker.io/library/busybox:1.36" }}'
-        command: ["sh", "-c"]
-        args:
-          - |
-            nc -zv api.cloudflare.com 443 2>&1 && echo "connected" || echo "connection_failed"
   analyzers:
-    # External DB connectivity analyzer
-    - textAnalyze:
-        checkName: External Database Connectivity
-        exclude: 'repl{{ ConfigOptionNotEquals "database_type" "external" }}'
-        fileName: dronerx-db-check.log
-        regex: "connected"
-        outcomes:
-          - fail:
-              when: "false"
-              message: |
-                Cannot connect to external database at repl{{ ConfigOption "external_db_host" }}:repl{{ ConfigOption "external_db_port" }}.
-                Verify the host, port, and credentials are correct and the database is reachable from this cluster.
-          - pass:
-              when: "true"
-              message: External database is reachable.
-    # Cloudflare API connectivity analyzer
-    - textAnalyze:
-        checkName: Cloudflare API Connectivity
-        exclude: 'repl{{ or (ConfigOptionNotEquals "tls_mode" "cloudflare") IsAirgap }}'
-        fileName: dronerx-cloudflare-check.log
-        regex: "connected"
-        outcomes:
-          - fail:
-              when: "false"
-              message: |
-                Cannot reach Cloudflare API at api.cloudflare.com:443.
-                cert-manager DNS-01 challenges require outbound HTTPS access to the Cloudflare API.
-                Ensure firewall and proxy rules allow outbound TCP to api.cloudflare.com on port 443.
-          - pass:
-              when: "true"
-              message: Cloudflare API is reachable.
     # 3.1c: Cluster CPU capacity
     - nodeResources:
         checkName: Cluster CPU Capacity


### PR DESCRIPTION
## Summary

The v1beta3 preflight spec at \`replicated/preflight-v1beta3.yaml\` is rendered via Helm templating — it does NOT support KOTS template functions like \`ConfigOptionNotEquals\` or \`IsAirgap\`. A previous commit added those, producing:

\`\`\`
failed to render v1beta3 template ...: function "ConfigOptionNotEquals" not defined
\`\`\`

Additional context: EC v3's built-in v1beta3 preflight runner is currently broken when the spec uses Helm \`.Values\` templating (it reads the YAML before the chart is templated). So the spec must stay static for now.

This reverts the v1beta3 file to the pre-change cluster-level static checks (K8s version, CPU, memory, distribution, storage class). The workload-specific conditional checks (external DB FQDN, Cloudflare API) remain in \`chart/templates/_preflight.tpl\` (v1beta2), where Helm \`.Values\` conditionals work correctly on the helm-CLI path.

This commit was originally pushed to \`feat/kots-config-expansion\` after that branch was already merged — opening it as a fresh PR off main.

## Test plan
- [ ] Create an EC v3 release, confirm preflight preprocess succeeds (no parse error)
- [ ] Helm-CLI install with external DB still triggers the \`_preflight.tpl\` v1beta2 DB FQDN check

🤖 Generated with [Claude Code](https://claude.com/claude-code)