### PR TITLE
Fix(ci): Use PAT for release-please to bypass approval gate

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -24,7 +24,7 @@ jobs:
         id: release
         with:
           release-type: simple
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   replicated-release:
     needs: release-please


### PR DESCRIPTION
## Summary

Release-please PRs opened via \`GITHUB_TOKEN\` are authored by \`github-actions[bot]\`, which trips the repo's first-time-contributor approval rule and blocks downstream workflow runs (\`conclusion: action_required\`).

Switch the token to \`RELEASE_PLEASE_TOKEN\` (fine-grained PAT, \`contents: write\` + \`pull-requests: write\` scoped to this repo). PRs will be authored by a collaborator, bypassing the approval gate and cascading downstream workflows normally.

**Before merging:** ensure the \`RELEASE_PLEASE_TOKEN\` repo secret exists (fine-grained PAT with Contents: RW + Pull requests: RW).

## Test plan
- [ ] Merge + push any commit to main, confirm release-please opens a new release PR without requiring approval
- [ ] Confirm downstream replicated-release workflow fires on tag creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)