### PR TITLE
Ci: Skip PR workflow on release-please bump PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,6 +3,12 @@ name: PR
 on:
   pull_request:
     branches: [main]
+    # Skip CI on release-please PRs (only CHANGELOG.md + manifest). Normal PRs
+    # that also touch these files still run because paths-ignore only skips
+    # when ALL changed files match.
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - '.release-please-manifest.json'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Every merge was triggering three full lint/build/cmx runs (feature PR → release-please PR → post-release-merge). The middle one is redundant since release-please PRs only bump \`CHANGELOG.md\` + \`.release-please-manifest.json\`.

Adds \`paths-ignore\` on those two files to skip the PR workflow. Normal PRs that happen to edit CHANGELOG still run CI because \`paths-ignore\` only skips when **all** changed paths match.

## Test plan
- [ ] Merge a feature PR, watch release-please open a bump PR, confirm no \`PR\` workflow run is triggered on it
- [ ] Confirm a regular PR touching code + CHANGELOG still runs CI
- [ ] Confirm post-merge release workflow (tag-triggered) still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)