### PR TITLE
Feat(traefik): Run on host network as DaemonSet for direct :80/:443

### DIFF
--- a/replicated/traefik-chart.yaml
+++ b/replicated/traefik-chart.yaml
@@ -21,11 +21,17 @@ spec:
     image:
       registry: 'repl{{ ReplicatedImageRegistry (HelmValue ".Values.image.registry") }}'
       repository: 'repl{{ ReplicatedImageRepository (HelmValue ".Values.image.repository") }}'
+    # Run Traefik in the host network namespace so it binds directly to
+    # the node's :80 and :443 instead of via a high-numbered NodePort.
+    hostNetwork: true
     service:
       type: repl{{ ConfigOption "traefik_service_type" }}
       nodePorts:
         http: 80
         https: 443
     deployment:
+      # DaemonSet pairs with hostNetwork so every node runs one Traefik
+      # pod and there are no port-conflict scheduling issues.
+      kind: DaemonSet
       imagePullSecrets:
         - name: enterprise-pull-secret


### PR DESCRIPTION
## Summary

Traefik's Service was landing on dynamic high NodePorts (\`80:11473, 443:3170\`) because Kubernetes' default node-port range is 30000-32767 and rejects <1024. External clients hitting the node on :443 would not reach Traefik.

Setting \`hostNetwork: true\` binds Traefik directly to the node's :80 and :443 via \`CAP_NET_BIND_SERVICE\` (which the upstream Traefik chart adds automatically), bypassing NodePort mapping entirely.

Pairing with \`kind: DaemonSet\` ensures one Traefik pod per node and side-steps the port-conflict scheduling issue that would arise with multiple Deployment replicas on the same node.

## Test plan
- [ ] Install on EC — confirm Traefik pods are DaemonSet, one per node, and binding to the host's :80 / :443
- [ ] Curl the node's \`https://<node-ip>:443/\` → reaches DroneRx frontend (previously required \`:3170\`)
- [ ] Verify DroneRx Ingress routing still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)