### PR TITLE
Feat(ec): Extend k0s NodePort range so Traefik binds :80/:443

### DIFF
--- a/replicated/embedded-cluster.yaml
+++ b/replicated/embedded-cluster.yaml
@@ -6,3 +6,16 @@ spec:
   version: "3.0.0-alpha-31+k8s-1.34"
   domains:
     proxyRegistryDomain: images.littleroom.co.nz
+  # Extend the kube-apiserver service-node-port-range so Traefik can
+  # bind 80/443 directly via its Service. Lower bound 80 avoids widening
+  # into <80 territory where SSH (22), DNS (53), SMTP (25), etc. could
+  # collide with a misconfigured NodePort. unsupportedOverrides is
+  # outside the Replicated support SLA and spec.api cannot be modified
+  # post-install — the range is locked in at first install.
+  unsupportedOverrides:
+    k0s: |
+      config:
+        spec:
+          api:
+            extraArgs:
+              service-node-port-range: "80-32767"


### PR DESCRIPTION
## Summary

Traefik's Service declares \`nodePorts: {http: 80, https: 443}\` but Kubernetes's default node-port range is 30000-32767, so the values were silently replaced with dynamic high ports (\`443:3170\`). External clients hitting the node on :443 never reached Traefik.

Patch kube-apiserver with \`--service-node-port-range=80-32767\` via EC's \`spec.unsupportedOverrides.k0s\`. Lower bound 80 covers both web ports without opening the <80 range where SSH/DNS/SMTP could collide with a misconfigured NodePort later.

## Why not hostNetwork (PR #117 — closed)

hostNetwork gives a compromised Traefik direct access to kubelet, cloud-metadata, and localhost services, and bypasses NetworkPolicies. Even outside regulated contexts those trade-offs are unacceptable for the small win.

## Caveats

- **\`unsupportedOverrides\` is outside the Replicated support SLA.** If k0s or EC change this contract, fix is on us.
- **Install-time lock-in.** Per EC docs, \`spec.api\` cannot be modified post-install. Range is locked at first install; changing it later requires re-install.
- **Validation required.** A typo in the override can fail k0s bootstrap. Test on throwaway CMX EC before anyone important installs.

## Test plan
- [ ] Release to unstable, install on fresh CMX EC
- [ ] \`kubectl -n kube-system get pod -l component=kube-apiserver -o yaml | grep service-node-port-range\` shows \`--service-node-port-range=80-32767\`
- [ ] \`kubectl -n traefik get svc traefik\` shows \`80:80/TCP,443:443/TCP\` (not dynamic high ports)
- [ ] \`curl -kv https://<node-ip>:443/\` from outside reaches DroneRx frontend
- [ ] Traefik pod has its own cluster IP (confirms pod-network isolation preserved, unlike hostNetwork)

🤖 Generated with [Claude Code](https://claude.com/claude-code)