### PR TITLE
Ci: Unchain release.yaml from release-please (fixes double release runs)

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -15,21 +15,10 @@ env:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
     steps:
       - uses: googleapis/release-please-action@v4
-        id: release
         with:
           release-type: simple
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-
-  replicated-release:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    uses: ./.github/workflows/release.yaml
-    with:
-      version: ${{ needs.release-please.outputs.version }}
-    secrets: inherit
+  # release.yaml fires on its own via `on.push.tags` when release-please
+  # pushes the new v*.*.* tag using the PAT. No workflow_call chain needed.


### PR DESCRIPTION
## Summary

Every release-please merge was triggering TWO full release pipelines:
1. \`release-please.yaml\` invoked \`release.yaml\` via \`workflow_call\`
2. \`release.yaml\` also fired independently on the \`v*.*.*\` tag push

The chain only existed to work around GitHub's rule that \`GITHUB_TOKEN\`-created events (like a tag push) don't trigger downstream workflow runs. Since PR #111 switched release-please to a PAT, that tag is authored by a real user and fires \`release.yaml\` directly. Chain is now redundant.

Drop the \`replicated-release\` job from \`release-please.yaml\`. \`release.yaml\` keeps its \`on.push.tags\` trigger as the single release entry point, and manual \`git tag vX.Y.Z && git push --tags\` still works for emergency releases.

## Test plan
- [ ] Merge a PR, let release-please open its bump PR, merge that → confirm only ONE "Replicated Release" run fires (tag-triggered), no duplicate
- [ ] Confirm the promote/attach still completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)