### PR TITLE
Fix(kots-config): Drop string-templated readonly to restore helm-cli availability

### DIFF
--- a/replicated/kots-config.yaml
+++ b/replicated/kots-config.yaml
@@ -176,13 +176,11 @@ spec:
       items:
         - name: live_tracking_enabled
           title: Live Drone Tracking
-          help_text: Stream real-time drone telemetry to the UI. Requires license entitlement.
+          help_text: Stream real-time drone telemetry to the UI. Requires the `live_tracking_enabled` license entitlement — toggling this on without entitlement has no effect (the HelmChart CR and-guards with the license field).
           type: bool
           default: 'repl{{ ternary "1" "0" (LicenseFieldValue "live_tracking_enabled" | ParseBool) }}'
-          readonly: 'repl{{ not (LicenseFieldValue "live_tracking_enabled" | ParseBool) }}'
         - name: light_mode_enabled
           title: Light / Dark Mode Toggle
-          help_text: Allow end users to switch UI theme. Requires license entitlement.
+          help_text: Allow end users to switch UI theme. Requires the `light_mode_enabled` license entitlement — toggling this on without entitlement has no effect (the HelmChart CR and-guards with the license field).
           type: bool
           default: 'repl{{ ternary "1" "0" (LicenseFieldValue "light_mode_enabled" | ParseBool) }}'
-          readonly: 'repl{{ not (LicenseFieldValue "light_mode_enabled" | ParseBool) }}'


### PR DESCRIPTION
## Summary

Only the Embedded Cluster install path was showing as available for new releases on the vendor portal; helm-cli + existing-cluster were marked unavailable.

\`replicated release lint\` revealed a schema error:

\`\`\`
config-is-invalid   replicated/kots-config.yaml
  failed to decode config content: json: cannot unmarshal string into
  Go struct field ConfigItem.spec.groups.items.readonly of type bool
\`\`\`

The rubric 5.1 change added \`readonly: 'repl{{ not (LicenseFieldValue ...) }}'\` on the two license-gated config items. KOTS's config schema requires \`readonly\` to be a literal boolean, so the templated string failed to decode. EC tolerates it via a different validation path, which is why only EC remained available.

## Fix

Drop the \`readonly\` field entirely. Layer 3 (the HelmChart CR \`and\`-guard against \`LicenseFieldValue\`) still enforces entitlement at render time — a non-entitled operator toggling the config on has no effect on the rendered values. The \`help_text\` is updated to explain that behavior.

## Trade-off

Lose the UX affordance of showing the toggle as greyed-out for non-entitled customers. The field is still visible (so they see the feature exists and can upgrade their license) and the \`default\` still comes from the license. Slightly worse UX, but the release is usable on helm-cli again.

## Test plan
- [ ] Run \`replicated release lint\` locally — confirm no \`config-is-invalid\` errors (ReplicatedImage* \`unable-to-render\` warnings are expected; those functions are server-side-only)
- [ ] Cut a release, confirm vendor portal shows both EC and helm-cli / existing-cluster availability
- [ ] Install via helm-cli, confirm config screen renders both toggles
- [ ] With a license lacking \`live_tracking_enabled\`, confirm toggling it on doesn't actually enable live tracking (HelmChart CR \`and\`-guard wins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)