### PR TITLE
Fix(airgap): Split self-signed cert job into openssl initContainer

### DIFF
--- a/chart/templates/self-signed-cert-job.yaml
+++ b/chart/templates/self-signed-cert-job.yaml
@@ -20,23 +20,39 @@ spec:
       imagePullSecrets:
         {{- include "dronerx.imagePullSecrets" . | nindent 8 }}
       serviceAccountName: {{ include "dronerx.fullname" . }}-cert-job
-      containers:
+      volumes:
+        - name: cert-data
+          emptyDir: {}
+      initContainers:
         - name: generate-cert
-          image: {{ .Values.selfSignedCert.image }}
+          image: {{ .Values.selfSignedCert.opensslImage }}
           command:
             - sh
             - -c
             - |
               openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-                -keyout /tmp/tls.key \
-                -out /tmp/tls.crt \
+                -keyout /tmp/cert/tls.key \
+                -out /tmp/cert/tls.crt \
                 -subj "/CN={{ .Values.ingress.hostname }}/O=dronerx" \
                 -addext "subjectAltName=DNS:{{ .Values.ingress.hostname }}"
+          volumeMounts:
+            - name: cert-data
+              mountPath: /tmp/cert
+      containers:
+        - name: apply-secret
+          image: {{ .Values.selfSignedCert.image }}
+          command:
+            - sh
+            - -c
+            - |
               kubectl create secret tls {{ include "dronerx.tlsSecretName" . }} \
-                --cert=/tmp/tls.crt \
-                --key=/tmp/tls.key \
+                --cert=/tmp/cert/tls.crt \
+                --key=/tmp/cert/tls.key \
                 --namespace={{ .Release.Namespace }} \
                 --dry-run=client -o yaml | kubectl apply -f -
+          volumeMounts:
+            - name: cert-data
+              mountPath: /tmp/cert
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -94,9 +94,12 @@ busybox:
   image: images.littleroom.co.nz/proxy/drone-rx/index.docker.io/library/busybox:1.36
 
 selfSignedCert:
-  # alpine/k8s ships with kubectl + openssl pre-installed (airgap-safe).
-  # Tag tracks the cluster k8s minor version for kubectl client compat.
+  # Main container runs kubectl to apply the generated Secret.
+  # Tag tracks the cluster k8s minor version for client compat.
   image: images.littleroom.co.nz/proxy/drone-rx/index.docker.io/alpine/k8s:1.34.7
+  # initContainer generates the self-signed cert (alpine/k8s doesn't
+  # ship openssl, so we split cert gen into a dedicated init step).
+  opensslImage: images.littleroom.co.nz/proxy/drone-rx/index.docker.io/alpine/openssl:3.5.6
 
 imagePullSecrets:
   - name: enterprise-pull-secret

--- a/replicated/dronerx-chart.yaml
+++ b/replicated/dronerx-chart.yaml
@@ -22,6 +22,7 @@ spec:
       image: 'repl{{ ReplicatedImageName (HelmValue ".Values.busybox.image") true }}'
     selfSignedCert:
       image: 'repl{{ ReplicatedImageName (HelmValue ".Values.selfSignedCert.image") true }}'
+      opensslImage: 'repl{{ ReplicatedImageName (HelmValue ".Values.selfSignedCert.opensslImage") true }}'
     api:
       image:
         registry: 'repl{{ ReplicatedImageRegistry (HelmValue ".Values.api.image.registry") true }}'


### PR DESCRIPTION
## Summary

The cert-job crashed with \`openssl: not found\`. I incorrectly assumed \`alpine/k8s:1.34.7\` ships with openssl — verified on Docker Hub that it only contains kubectl/helm/curl/jq.

## Fix

Split into two phases:
1. **initContainer** \`alpine/openssl:3.5.6\` — generates \`tls.key\` and \`tls.crt\` into a shared emptyDir
2. **main container** \`alpine/k8s:1.34.7\` — reads those files and applies them as a kubernetes.io/tls Secret via kubectl

Verified before pushing this time:
\`\`\`
$ docker run --rm alpine/openssl:3.5.6 openssl version
OpenSSL 3.5.6

$ docker run --rm alpine/k8s:1.34.7 kubectl version --client
Client Version: v1.34.7
\`\`\`

## Airgap coverage

- New \`.Values.selfSignedCert.opensslImage\` wrapped in \`ReplicatedImageName ... true\` so airgap installs rewrite it to the local registry
- The existing \`builder.ingress.tls.mode=self-signed\` override still forces the job to render during airgap bundle build, so **both** images get scanned and included in the bundle

## Test plan
- [ ] Helm-CLI install with self-signed TLS → cert-job initContainer completes, main container applies Secret, Ingress Ready
- [ ] Cut a release and inspect the airgap bundle manifest for both \`alpine/openssl:3.5.6\` and \`alpine/k8s:1.34.7\`
- [ ] Install the bundle on no-egress EC → cert-job completes, TLS Secret exists, rest of release renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)