### PR TITLE
Fix(external-db): Unquote postgres instances so YAML parses as integer

### DIFF
--- a/replicated/dronerx-chart.yaml
+++ b/replicated/dronerx-chart.yaml
@@ -54,7 +54,7 @@ spec:
       # instances/storage/password fall back to literals on external DB
       # because their ConfigOptions are `when`-gated to embedded and would
       # render empty, failing chart schema validation (instances>=1).
-      instances: 'repl{{ ConfigOption "postgres_instances" | default "1" | ParseInt }}'
+      instances: repl{{ ConfigOption "postgres_instances" | default "1" | ParseInt }}
       storage:
         size: 'repl{{ ConfigOption "postgres_storage_size" | default "1Gi" }}'
       password: 'repl{{ ConfigOption "db_password" }}'


### PR DESCRIPTION
## Summary

PR #125's defensive \`default\` fix wrapped \`postgresql.instances\` in single quotes for consistency. That turned the rendered value into a YAML string and the next install failed with:

\`\`\`
at '/postgresql/instances': got string, want integer
\`\`\`

Drop the quotes so \`ParseInt\`'s output is YAML-parsed as a number. \`storage.size\` stays quoted because it IS a string.

## Test plan
- [ ] EC online install with \`database_type=external\` → passes schema validation
- [ ] EC online install with \`database_type=embedded\`, instances=3 → renders as integer 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)