### PR TITLE
Fix(traefik): Use per-entrypoint nodePort path + drop redundant k0s override

### DIFF
--- a/replicated/embedded-cluster.yaml
+++ b/replicated/embedded-cluster.yaml
@@ -6,16 +6,3 @@ spec:
   version: "3.0.0-alpha-31+k8s-1.34"
   domains:
     proxyRegistryDomain: images.littleroom.co.nz
-  # Extend the kube-apiserver service-node-port-range so Traefik can
-  # bind 80/443 directly via its Service. Lower bound 80 avoids widening
-  # into <80 territory where SSH (22), DNS (53), SMTP (25), etc. could
-  # collide with a misconfigured NodePort. unsupportedOverrides is
-  # outside the Replicated support SLA and spec.api cannot be modified
-  # post-install — the range is locked in at first install.
-  unsupportedOverrides:
-    k0s: |
-      config:
-        spec:
-          api:
-            extraArgs:
-              service-node-port-range: "80-32767"

--- a/replicated/traefik-chart.yaml
+++ b/replicated/traefik-chart.yaml
@@ -23,9 +23,15 @@ spec:
       repository: 'repl{{ ReplicatedImageRepository (HelmValue ".Values.image.repository") }}'
     service:
       type: repl{{ ConfigOption "traefik_service_type" }}
-      nodePorts:
-        http: 3080
-        https: 30443
+    # Traefik v3 configures NodePorts per-entrypoint under ports.<name>.nodePort,
+    # NOT under service.nodePorts — the latter silently gets ignored and k8s
+    # picks random ports from the extended 80-32767 range that EC's k0s config
+    # sets by default (pkg/k0s/config.go L167-169).
+    ports:
+      web:
+        nodePort: 3080
+      websecure:
+        nodePort: 30443
     deployment:
       imagePullSecrets:
         - name: enterprise-pull-secret


### PR DESCRIPTION
## Summary

Two related fixes:

### 1. Traefik v3 nodePort path was wrong
The HelmChart CR was setting \`service.nodePorts.{http,https}\` which isn't a valid key in Traefik v3's chart — the values silently got dropped and Kubernetes picked random NodePorts from the extended range:

\`\`\`
traefik   NodePort   10.244.169.79   <none>   80:8043/TCP,443:28326/TCP
\`\`\`

Traefik v3 uses per-entrypoint NodePorts at \`ports.<entrypoint>.nodePort\` instead:

\`\`\`yaml
ports:
  web:
    nodePort: 3080
  websecure:
    nodePort: 30443
\`\`\`

### 2. Redundant \`unsupportedOverrides.k0s\`
EC v3 already sets \`--service-node-port-range=80-32767\` by default in its k0s config ([pkg/k0s/config.go L167-169](https://github.com/replicatedhq/ec/blob/0ea20cf0eb442b136a223da13343164cbd873d83/pkg/k0s/config.go#L167-L169)). The \`unsupportedOverrides.k0s\` we added in PR #118 was duplicating what's already configured. Dropped.

## Test plan
- [ ] Install on EC, confirm \`kubectl -n traefik get svc traefik\` shows \`80:3080/TCP,443:30443/TCP\`
- [ ] \`curl -kv https://<node-ip>:30443/\` reaches DroneRx frontend
- [ ] Confirm the kube-apiserver still has the extended NodePort range from EC defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)