### PR TITLE
Feat(config): Split rubric 4.7 (license) from 5.1 (plain config)

### DIFF
--- a/chart/templates/configmap-api.yaml
+++ b/chart/templates/configmap-api.yaml
@@ -12,3 +12,4 @@ data:
   REPLICATED_SDK_URL: "http://drone-rx-sdk:3000"
   LIVE_TRACKING_ENABLED: {{ .Values.api.liveTrackingEnabled | quote }}
   LIGHT_MODE_ENABLED: {{ .Values.api.lightModeEnabled | quote }}
+  ADMIN_LINK_VISIBLE: {{ .Values.api.adminLinkVisible | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -17,6 +17,7 @@ api:
   webhookURL: ""
   liveTrackingEnabled: "true"
   lightModeEnabled: "false"
+  adminLinkVisible: "false"
 
 frontend:
   image:

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -125,13 +125,13 @@ func main() {
 	}
 	defer nc.Drain()
 
-	// 4a. Create Replicated SDK client
+	// 4a. Create Replicated SDK client. The only license-gated feature we
+	// override is live_tracking_enabled; UI-level toggles (light mode, admin
+	// link) are plain config and served from the env directly by the
+	// UIConfigHandler below.
 	sdkClient := sdk.NewClient(cfg.SDKUrl)
 	if cfg.LiveTrackingEnabled != "" {
 		sdkClient.SetFeatureOverride("live_tracking_enabled", cfg.LiveTrackingEnabled)
-	}
-	if cfg.LightModeEnabled != "" {
-		sdkClient.SetFeatureOverride("light_mode_enabled", cfg.LightModeEnabled)
 	}
 
 	// 5. Create stores
@@ -157,6 +157,7 @@ func main() {
 	licenseHandler := handlers.NewLicenseHandler(sdkClient)
 	updatesHandler := handlers.NewUpdatesHandler(sdkClient)
 	adminHandler := handlers.NewAdminHandler(cfg.Namespace, cfg.SDKUrl, "sh", nil)
+	uiConfigHandler := handlers.NewUIConfigHandler(cfg.LightModeEnabled, cfg.AdminLinkVisible)
 
 	// 9. Set up routes
 	mux := http.NewServeMux()
@@ -168,6 +169,7 @@ func main() {
 	mux.HandleFunc("GET /api/orders", orderHandler.List)
 	mux.Handle("GET /api/orders/{id}/track", trackingHandler)
 	mux.HandleFunc("GET /api/license/status", licenseHandler.Status)
+	mux.HandleFunc("GET /api/config/ui", uiConfigHandler.Get)
 	mux.HandleFunc("GET /api/updates", updatesHandler.Check)
 	mux.HandleFunc("POST /api/admin/support-bundle", adminHandler.GenerateSupportBundle)
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Medicine, Order, CreateOrderRequest, LicenseStatus, UpdateInfo, SupportBundleResponse } from './types';
+import type { Medicine, Order, CreateOrderRequest, LicenseStatus, UIConfig, UpdateInfo, SupportBundleResponse } from './types';
 
 const BASE_URL = '/api';
 
@@ -42,6 +42,10 @@ export function connectTracking(orderID: string): WebSocket {
 
 export async function getLicenseStatus(): Promise<LicenseStatus> {
 	return fetchJSON<LicenseStatus>(`${BASE_URL}/license/status`);
+}
+
+export async function getUIConfig(): Promise<UIConfig> {
+	return fetchJSON<UIConfig>(`${BASE_URL}/config/ui`);
 }
 
 export async function getUpdates(): Promise<UpdateInfo[]> {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -40,7 +40,11 @@ export interface LicenseStatus {
 	license_type?: string;
 	expiration_date?: string;
 	live_tracking_enabled: boolean;
+}
+
+export interface UIConfig {
 	light_mode_enabled: boolean;
+	admin_link_visible: boolean;
 }
 
 export interface UpdateInfo {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import '../app.css';
 	import { onMount, setContext } from 'svelte';
-	import { getUpdates, getLicenseStatus } from '$lib/api';
+	import { getUpdates, getLicenseStatus, getUIConfig } from '$lib/api';
 	import type { UpdateInfo, LicenseStatus } from '$lib/types';
 	import { theme } from '$lib/stores/theme';
 	import { writable } from 'svelte/store';
@@ -15,24 +15,30 @@
 	let showUpdateBanner = $derived(latestUpdate !== null && !bannerDismissed);
 	let showLicenseWarning = $derived(license !== null && (license.expired || !license.valid));
 
-	// Expose light_mode_enabled to child pages via context
+	// UI toggles sourced from plain config (not license-gated).
 	const lightModeEnabled = writable(false);
+	const adminLinkVisible = writable(false);
 	setContext('lightModeEnabled', lightModeEnabled);
+	setContext('adminLinkVisible', adminLinkVisible);
 
 	onMount(async () => {
 		theme.init();
 
 		try {
-			const [updates, licenseStatus] = await Promise.all([
+			const [updates, licenseStatus, uiConfig] = await Promise.all([
 				getUpdates().catch(() => []),
 				getLicenseStatus().catch(() => null),
+				getUIConfig().catch(() => null),
 			]);
 			if (updates && updates.length > 0) {
 				latestUpdate = updates[0];
 			}
 			if (licenseStatus) {
 				license = licenseStatus;
-				lightModeEnabled.set(licenseStatus.light_mode_enabled ?? false);
+			}
+			if (uiConfig) {
+				lightModeEnabled.set(uiConfig.light_mode_enabled ?? false);
+				adminLinkVisible.set(uiConfig.admin_link_visible ?? false);
 			}
 		} catch {
 			// silent — banners are non-critical

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -8,6 +8,7 @@
 	import type { Writable } from 'svelte/store';
 
 	const lightModeEnabled = getContext<Writable<boolean>>('lightModeEnabled');
+	const adminLinkVisible = getContext<Writable<boolean>>('adminLinkVisible');
 
 	let { data }: { data: PageData } = $props();
 
@@ -33,6 +34,14 @@
 			<span class="text-xs text-navy-300 hidden sm:inline ml-1 font-medium">Aerial Pharmacy</span>
 		</div>
 		<nav class="flex items-center gap-4">
+			{#if $adminLinkVisible}
+				<a
+					href="/admin"
+					class="text-sm font-medium text-navy-200 hover:text-cyan-glow transition-colors"
+				>
+					Admin
+				</a>
+			{/if}
 			<a
 				href="/orders"
 				class="text-sm font-medium text-navy-200 hover:text-cyan-glow transition-colors"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Namespace           string
 	LiveTrackingEnabled string
 	LightModeEnabled    string
+	AdminLinkVisible    string
 }
 
 func Load() Config {
@@ -28,6 +29,7 @@ func Load() Config {
 		Namespace:           getEnv("POD_NAMESPACE", "default"),
 		LiveTrackingEnabled: getEnv("LIVE_TRACKING_ENABLED", "true"),
 		LightModeEnabled:    getEnv("LIGHT_MODE_ENABLED", "false"),
+		AdminLinkVisible:    getEnv("ADMIN_LINK_VISIBLE", "false"),
 	}
 }
 

--- a/internal/handlers/license.go
+++ b/internal/handlers/license.go
@@ -23,7 +23,6 @@ type licenseStatusResponse struct {
 	LicenseType         string `json:"license_type"`
 	ExpirationDate      string `json:"expiration_date"`
 	LiveTrackingEnabled bool   `json:"live_tracking_enabled"`
-	LightModeEnabled    bool   `json:"light_mode_enabled"`
 }
 
 // Status handles GET /api/license/status.
@@ -37,13 +36,11 @@ func (h *LicenseHandler) Status(w http.ResponseWriter, r *http.Request) {
 			Valid:               true,
 			Expired:             false,
 			LiveTrackingEnabled: false,
-			LightModeEnabled:    false,
 		})
 		return
 	}
 
 	liveTracking := h.client.IsFeatureEnabled("live_tracking_enabled")
-	lightMode := h.client.IsFeatureEnabled("light_mode_enabled")
 
 	json.NewEncoder(w).Encode(licenseStatusResponse{
 		Valid:               !info.IsExpired(),
@@ -51,6 +48,5 @@ func (h *LicenseHandler) Status(w http.ResponseWriter, r *http.Request) {
 		LicenseType:         info.LicenseType,
 		ExpirationDate:      info.ExpirationDate(),
 		LiveTrackingEnabled: liveTracking,
-		LightModeEnabled:    lightMode,
 	})
 }

--- a/internal/handlers/license_test.go
+++ b/internal/handlers/license_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jwilson/dronerx/internal/sdk"
 )
 
-func TestLicenseStatus_IncludesLightMode(t *testing.T) {
+func TestLicenseStatus_IncludesLiveTracking(t *testing.T) {
 	sdkSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
@@ -25,8 +25,6 @@ func TestLicenseStatus_IncludesLightMode(t *testing.T) {
 			}`))
 		case "/api/v1/license/fields/live_tracking_enabled":
 			json.NewEncoder(w).Encode(sdk.LicenseField{Name: "live_tracking_enabled", Value: true, ValueType: "Boolean"})
-		case "/api/v1/license/fields/light_mode_enabled":
-			json.NewEncoder(w).Encode(sdk.LicenseField{Name: "light_mode_enabled", Value: true, ValueType: "Boolean"})
 		default:
 			http.NotFound(w, r)
 		}
@@ -49,13 +47,9 @@ func TestLicenseStatus_IncludesLightMode(t *testing.T) {
 		Expired             bool   `json:"expired"`
 		LicenseType         string `json:"license_type"`
 		LiveTrackingEnabled bool   `json:"live_tracking_enabled"`
-		LightModeEnabled    bool   `json:"light_mode_enabled"`
 	}
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode error: %v", err)
-	}
-	if !resp.LightModeEnabled {
-		t.Error("expected light_mode_enabled to be true")
 	}
 	if !resp.LiveTrackingEnabled {
 		t.Error("expected live_tracking_enabled to be true")
@@ -79,14 +73,14 @@ func TestLicenseStatus_SDKDown_DefaultsFalse(t *testing.T) {
 	handler.Status(rr, req)
 
 	var resp struct {
-		LightModeEnabled bool `json:"light_mode_enabled"`
-		Valid            bool `json:"valid"`
+		LiveTrackingEnabled bool `json:"live_tracking_enabled"`
+		Valid               bool `json:"valid"`
 	}
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode error: %v", err)
 	}
-	if resp.LightModeEnabled {
-		t.Error("expected light_mode_enabled false when SDK down")
+	if resp.LiveTrackingEnabled {
+		t.Error("expected live_tracking_enabled false when SDK down")
 	}
 	if !resp.Valid {
 		t.Error("expected valid true when SDK down (fail open)")

--- a/internal/handlers/ui_config.go
+++ b/internal/handlers/ui_config.go
@@ -1,0 +1,40 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// UIConfigHandler serves plain UI config values (not license-gated).
+// Values are read from env vars at init time — no SDK calls.
+type UIConfigHandler struct {
+	lightModeEnabled bool
+	adminLinkVisible bool
+}
+
+// NewUIConfigHandler constructs the handler from string env-var values.
+// Accepts "true" or "1" as truthy; anything else is false.
+func NewUIConfigHandler(lightMode, adminLink string) *UIConfigHandler {
+	return &UIConfigHandler{
+		lightModeEnabled: truthy(lightMode),
+		adminLinkVisible: truthy(adminLink),
+	}
+}
+
+type uiConfigResponse struct {
+	LightModeEnabled bool `json:"light_mode_enabled"`
+	AdminLinkVisible bool `json:"admin_link_visible"`
+}
+
+// Get handles GET /api/config/ui.
+func (h *UIConfigHandler) Get(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(uiConfigResponse{
+		LightModeEnabled: h.lightModeEnabled,
+		AdminLinkVisible: h.adminLinkVisible,
+	})
+}
+
+func truthy(v string) bool {
+	return v == "true" || v == "1"
+}

--- a/internal/handlers/ui_config_test.go
+++ b/internal/handlers/ui_config_test.go
@@ -1,0 +1,52 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jwilson/dronerx/internal/handlers"
+)
+
+func TestUIConfig_Truthy(t *testing.T) {
+	cases := []struct {
+		name             string
+		lightMode        string
+		adminLink        string
+		wantLight        bool
+		wantAdminVisible bool
+	}{
+		{"both true", "true", "true", true, true},
+		{"both one", "1", "1", true, true},
+		{"both false", "false", "false", false, false},
+		{"mixed", "true", "false", true, false},
+		{"empty", "", "", false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := handlers.NewUIConfigHandler(tc.lightMode, tc.adminLink)
+			req := httptest.NewRequest(http.MethodGet, "/api/config/ui", nil)
+			rr := httptest.NewRecorder()
+			h.Get(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rr.Code)
+			}
+			var resp struct {
+				LightModeEnabled bool `json:"light_mode_enabled"`
+				AdminLinkVisible bool `json:"admin_link_visible"`
+			}
+			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if resp.LightModeEnabled != tc.wantLight {
+				t.Errorf("light_mode_enabled: got %v want %v", resp.LightModeEnabled, tc.wantLight)
+			}
+			if resp.AdminLinkVisible != tc.wantAdminVisible {
+				t.Errorf("admin_link_visible: got %v want %v", resp.AdminLinkVisible, tc.wantAdminVisible)
+			}
+		})
+	}
+}

--- a/replicated/dronerx-chart.yaml
+++ b/replicated/dronerx-chart.yaml
@@ -29,8 +29,11 @@ spec:
         repository: 'repl{{ ReplicatedImageRepository (HelmValue ".Values.api.image.repository") true }}'
       replicas: repl{{ ConfigOption "api_replicas" | ParseInt }}
       tickerInterval: repl{{ ConfigOption "api_ticker_interval" | ParseInt }}
+      # Live tracking — license-gated; and-guard enforces entitlement even if an operator toggles the config on without a license.
       liveTrackingEnabled: 'repl{{ and (ConfigOptionEquals "live_tracking_enabled" "1") (LicenseFieldValue "live_tracking_enabled" | ParseBool) }}'
-      lightModeEnabled: 'repl{{ and (ConfigOptionEquals "light_mode_enabled" "1") (LicenseFieldValue "light_mode_enabled" | ParseBool) }}'
+      # Light mode and admin link — plain config options (not license-gated).
+      lightModeEnabled: repl{{ ConfigOptionEquals "light_mode_enabled" "1" }}
+      adminLinkVisible: repl{{ ConfigOptionEquals "admin_link_visible" "1" }}
       webhookURL: repl{{ ConfigOption "webhook_url" }}
     frontend:
       image:

--- a/replicated/kots-config.yaml
+++ b/replicated/kots-config.yaml
@@ -170,17 +170,36 @@ spec:
             regex:
               pattern: '^$|^https?://[^\s]+$'
               message: Must be blank or a valid http(s) URL.
-    - name: features
-      title: Features
-      description: Entitlement-gated features. Disabled options are unavailable on your current license.
+    - name: ui
+      title: User Interface
+      description: Optional UI features visible to all end users.
       items:
-        - name: live_tracking_enabled
-          title: Live Drone Tracking
-          help_text: Stream real-time drone telemetry to the UI. Requires the `live_tracking_enabled` license entitlement — toggling this on without entitlement has no effect (the HelmChart CR and-guards with the license field).
-          type: bool
-          default: 'repl{{ ternary "1" "0" (LicenseFieldValue "live_tracking_enabled" | ParseBool) }}'
         - name: light_mode_enabled
           title: Light / Dark Mode Toggle
-          help_text: Allow end users to switch UI theme. Requires the `light_mode_enabled` license entitlement — toggling this on without entitlement has no effect (the HelmChart CR and-guards with the license field).
+          help_text: Allow end users to switch between light and dark themes via a toggle in the main site header.
           type: bool
-          default: 'repl{{ ternary "1" "0" (LicenseFieldValue "light_mode_enabled" | ParseBool) }}'
+          default: "0"
+        - name: admin_link_visible
+          title: Show Admin Link
+          help_text: Display an "Admin" link in the main site header pointing to operational tooling at /admin (support bundle, webhooks, observability).
+          type: bool
+          default: "0"
+    - name: features
+      title: Features
+      description: Entitlement-gated paying features. Locked items are unavailable on your current license — contact your vendor to upgrade.
+      items:
+        # Live Drone Tracking — editable when the license entitles this feature.
+        - name: live_tracking_enabled
+          title: Live Drone Tracking
+          help_text: Stream real-time drone telemetry to the UI.
+          type: bool
+          default: "1"
+          when: 'repl{{ LicenseFieldValue "live_tracking_enabled" | ParseBool }}'
+        # Live Drone Tracking — greyed-out placeholder shown when the license lacks the entitlement.
+        - name: live_tracking_enabled_locked
+          title: Live Drone Tracking
+          help_text: Your license does not include the live_tracking_enabled entitlement. Contact your vendor to upgrade.
+          type: bool
+          default: "0"
+          readonly: true
+          when: 'repl{{ not (LicenseFieldValue "live_tracking_enabled" | ParseBool) }}'


### PR DESCRIPTION
## Summary

Previously \`live_tracking_enabled\` and \`light_mode_enabled\` were both license-gated. But light/dark mode isn't a paying feature — it's a UI preference — so it doesn't belong on the license path. This splits them and adds a second plain config option (\`admin_link_visible\`) to cleanly satisfy both rubric items.

## Rubric mapping after this PR

- **4.7** (license entitlement gates a configurable feature, hidden or locked): \`live_tracking_enabled\` → greyed-out locked toggle when the operator's license lacks the entitlement, editable when entitled. Tier 6's \`terraform\` will follow the same pattern.
- **5.1** (≥2 non-trivial plain config-screen features): \`light_mode_enabled\` + \`admin_link_visible\` — toggled via config screen, demonstrably change app UI.

## Key change: two-item swap pattern for locked display

KOTS config schema requires \`readonly\` to be a literal bool (no templates). To still render a greyed-out toggle when the license is false, the \`features\` group has two mutually-exclusive items for Live Tracking:

\`\`\`yaml
- name: live_tracking_enabled          # editable, when license=true
  when: 'repl{{ LicenseFieldValue "live_tracking_enabled" | ParseBool }}'
  default: "1"
- name: live_tracking_enabled_locked   # readonly:true (literal), when license=false
  readonly: true
  when: 'repl{{ not (LicenseFieldValue "live_tracking_enabled" | ParseBool) }}'
  help_text: Your license does not include ... Contact your vendor to upgrade.
\`\`\`

Same title, different \`name\`. The HelmChart CR and-guard still references the canonical name; when that item is when-hidden, \`ConfigOption\` returns empty and the and short-circuits to false.

## Other changes

- New \`ui\` config group with \`light_mode_enabled\` and \`admin_link_visible\` (both plain bool, no license)
- New \`/api/config/ui\` endpoint served by \`UIConfigHandler\` — reads env vars at init; no SDK calls (it's plain config)
- \`light_mode_enabled\` removed from \`/api/license/status\` response; clients now use \`/api/config/ui\`
- Frontend fetches \`getUIConfig()\` alongside license status on layout mount; exposes \`adminLinkVisible\` context
- Home header renders an Admin link when \`$adminLinkVisible\`

## Test plan
- [x] \`go test ./internal/...\` — all pass including new \`UIConfigHandler\` test cases
- [x] \`helm template --set api.adminLinkVisible=true\` — ConfigMap includes \`ADMIN_LINK_VISIBLE: "true"\`
- [x] \`replicated release lint\` — no new errors
- [ ] KOTS install with license **having** \`live_tracking_enabled=true\` — editable toggle in features group, default on
- [ ] KOTS install with license **lacking** \`live_tracking_enabled\` — greyed-out readonly toggle with upsell help_text
- [ ] KOTS install: flip \`light_mode_enabled\` / \`admin_link_visible\` toggles in config; re-deploy; confirm theme toggle and Admin link appear/disappear
- [ ] Helm-CLI install with \`--set api.adminLinkVisible=true\` — Admin link renders on home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)