### PR TITLE
Fix(kots-config): Render locked live-tracking toggle as readonly text, not bool

### DIFF
--- a/replicated/kots-config.yaml
+++ b/replicated/kots-config.yaml
@@ -195,11 +195,14 @@ spec:
           type: bool
           default: "1"
           when: 'repl{{ LicenseFieldValue "live_tracking_enabled" | ParseBool }}'
-        # Live Drone Tracking — greyed-out placeholder shown when the license lacks the entitlement.
+        # Live Drone Tracking — locked placeholder shown when the license lacks
+        # the entitlement. Uses type=text + readonly so the admin console renders
+        # it as a disabled/greyed field — KOTS bool checkboxes with readonly=true
+        # still render as clickable in the UI (server rejects saves but UX is confusing).
         - name: live_tracking_enabled_locked
           title: Live Drone Tracking
           help_text: Your license does not include the live_tracking_enabled entitlement. Contact your vendor to upgrade.
-          type: bool
-          default: "0"
+          type: text
+          value: "🔒 Locked — license upgrade required"
           readonly: true
           when: 'repl{{ not (LicenseFieldValue "live_tracking_enabled" | ParseBool) }}'


### PR DESCRIPTION
## Summary

User reported that the "Live Drone Tracking" locked placeholder in the config screen was still clickable (tickable) despite \`readonly: true\`. Confirmed by inspection: KOTS admin console UI doesn't visually disable \`type: bool\` checkboxes when \`readonly: true\` — the box appears normal and lets the user tick it (the server rejects the save, but the UX is misleading).

## Fix

Change the locked placeholder from \`type: bool\` to \`type: text\` with:

\`\`\`yaml
type: text
value: "🔒 Locked — license upgrade required"
readonly: true
\`\`\`

\`text\` + \`readonly\` renders as a greyed/disabled input field that clearly communicates "locked" and isn't interactive. Help_text still says "Your license does not include the live_tracking_enabled entitlement. Contact your vendor to upgrade."

The editable bool item (shown when \`LicenseFieldValue = true\`) is unchanged. Only the non-entitled placeholder changes type. The HelmChart CR \`and\`-guard continues to reference the canonical \`live_tracking_enabled\` name and short-circuits to false when the license is false.

## Test plan
- [ ] KOTS install with license lacking \`live_tracking_enabled\` → config screen renders a disabled text field "🔒 Locked — license upgrade required" under "Live Drone Tracking". Cannot be interacted with.
- [ ] KOTS install with license having \`live_tracking_enabled=true\` → config screen renders the editable bool toggle, default on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)