### PR TITLE
Fix(chart): Roll api pods on ConfigMap change via checksum annotation

### DIFF
--- a/chart/templates/api-deployment.yaml
+++ b/chart/templates/api-deployment.yaml
@@ -11,6 +11,11 @@ spec:
       {{- include "dronerx.api.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        # Roll the api pods when the ConfigMap content changes so KOTS config
+        # changes (light_mode_enabled, admin_link_visible, ticker_interval, etc.)
+        # propagate on `helm upgrade` without a manual restart.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-api.yaml") . | sha256sum }}
       labels:
         {{- include "dronerx.api.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
## Summary

On EC v3 upgrade (and any \`helm upgrade\`), KOTS config changes weren't taking effect in the running app until pods were manually restarted. User reported unticking \`light_mode_enabled\`/\`admin_link_visible\` during config update and redeploying, with no UI change.

## Root cause

Kubernetes doesn't automatically restart pods that reference a ConfigMap via \`envFrom\` / \`valueFrom: configMapKeyRef\` when the ConfigMap content changes. KOTS re-renders and re-applies the new ConfigMap on upgrade, but the existing api pod keeps running with the stale env vars it cached at startup. The frontend then fetches \`/api/config/ui\` from the old pod and sees old values.

Not EC-specific — standard Helm/K8s behavior, would bite any upgrade on any install type.

## Fix

Add a \`checksum/config\` annotation to the api Deployment's pod template, derived from the rendered \`configmap-api.yaml\`. When the ConfigMap content changes on upgrade, the checksum changes, which Helm sees as a pod-spec diff, which triggers a rolling restart of the api deployment. New pods read the new env vars.

\`\`\`yaml
template:
  metadata:
    annotations:
      checksum/config: {{ include (print $.Template.BasePath "/configmap-api.yaml") . | sha256sum }}
\`\`\`

The api is the only deployment that reads the ConfigMap directly. Frontend is a static site that fetches \`/api/config/ui\` at runtime, so once the api pod restarts the frontend's next fetch gets fresh values — no checksum needed there.

## Test plan
- [ ] EC v3 install with \`admin_link_visible=true\`, confirm Admin link shows
- [ ] KOTS config screen: untick \`admin_link_visible\`, click Save Config, click Deploy
- [ ] \`kubectl -n <ns> rollout status deploy/drone-rx-api\` shows a fresh rollout
- [ ] Refresh frontend → Admin link is gone
- [ ] Same flow for \`light_mode_enabled\` → ThemeToggle appears/disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)