### PR TITLE
fix(support-bundle): Use correct CNPG operator deployment name on EC/KOTS

### DIFF
--- a/chart/templates/_supportbundle.tpl
+++ b/chart/templates/_supportbundle.tpl
@@ -89,11 +89,13 @@ spec:
           - pass:
               message: DroneRx frontend is running.
     {{- /* CNPG operator deployment name depends on how it was installed:
-           - Helm CLI: cnpgOperator.managed=true, installed as a subchart of drone-rx
-             → deployment: <release>-cloudnative-pg (e.g. drone-rx-cloudnative-pg)
+           - Helm CLI: cnpgOperator.managed=true, installed as a subchart
+             of drone-rx → deployment: <release>-cloudnative-pg
+             (e.g. drone-rx-cloudnative-pg).
            - KOTS/EC: cnpgOperator.managed=false, installed via a separate
-             HelmChart CR named "cnpg-operator"
-             → deployment: cnpg-operator-cloudnative-pg, namespace may differ */}}
+             HelmChart CR. KOTS uses the chart name ("cloudnative-pg") as the
+             Helm release name, and the chart's fullname helper collapses
+             release==chartname to just "cloudnative-pg". */}}
     {{- if .Values.cnpgOperator.managed }}
     - deploymentStatus:
         name: {{ include "dronerx.fullname" . }}-cloudnative-pg
@@ -109,17 +111,18 @@ spec:
               message: CNPG Operator (subchart) is running.
     {{- else }}
     - deploymentStatus:
-        name: cnpg-operator-cloudnative-pg
+        name: cloudnative-pg
         namespace: {{ .Release.Namespace }}
         outcomes:
           - fail:
               when: "< 1"
               message: |
-                The CNPG Operator deployment (installed via the cnpg-operator HelmChart CR)
-                has no available replicas. Postgres is unmanaged — users cannot place or track orders.
-                Run: kubectl describe deployment cnpg-operator-cloudnative-pg -n {{ .Release.Namespace }}
+                The CNPG Operator deployment (installed by KOTS via the cnpg-operator
+                HelmChart CR) has no available replicas. Postgres is unmanaged — users
+                cannot place or track orders.
+                Run: kubectl describe deployment cloudnative-pg -n {{ .Release.Namespace }}
           - pass:
-              message: CNPG Operator (cnpg-operator release) is running.
+              message: CNPG Operator is running.
     {{- end }}
     - statefulsetStatus:
         name: {{ .Release.Name }}-nats

--- a/chart/templates/_supportbundle.tpl
+++ b/chart/templates/_supportbundle.tpl
@@ -88,6 +88,13 @@ spec:
                 Run: kubectl describe deployment {{ include "dronerx.fullname" . }}-frontend -n {{ .Release.Namespace }}
           - pass:
               message: DroneRx frontend is running.
+    {{- /* CNPG operator deployment name depends on how it was installed:
+           - Helm CLI: cnpgOperator.managed=true, installed as a subchart of drone-rx
+             → deployment: <release>-cloudnative-pg (e.g. drone-rx-cloudnative-pg)
+           - KOTS/EC: cnpgOperator.managed=false, installed via a separate
+             HelmChart CR named "cnpg-operator"
+             → deployment: cnpg-operator-cloudnative-pg, namespace may differ */}}
+    {{- if .Values.cnpgOperator.managed }}
     - deploymentStatus:
         name: {{ include "dronerx.fullname" . }}-cloudnative-pg
         namespace: {{ .Release.Namespace }}
@@ -95,11 +102,25 @@ spec:
           - fail:
               when: "< 1"
               message: |
-                The DroneRx CNPG Operator deployment has no available replicas.
-                The Postgres Operator is down, The application is unavailable — users cannot place or track orders.
-                Run: kubectl describe deployment {{ include "dronerx.fullname" . }}-frontend -n {{ .Release.Namespace }}
+                The DroneRx CNPG Operator deployment (subchart) has no available replicas.
+                The Postgres Operator is down — users cannot place or track orders.
+                Run: kubectl describe deployment {{ include "dronerx.fullname" . }}-cloudnative-pg -n {{ .Release.Namespace }}
           - pass:
-              message: CNPG Operator is running.
+              message: CNPG Operator (subchart) is running.
+    {{- else }}
+    - deploymentStatus:
+        name: cnpg-operator-cloudnative-pg
+        namespace: {{ .Release.Namespace }}
+        outcomes:
+          - fail:
+              when: "< 1"
+              message: |
+                The CNPG Operator deployment (installed via the cnpg-operator HelmChart CR)
+                has no available replicas. Postgres is unmanaged — users cannot place or track orders.
+                Run: kubectl describe deployment cnpg-operator-cloudnative-pg -n {{ .Release.Namespace }}
+          - pass:
+              message: CNPG Operator (cnpg-operator release) is running.
+    {{- end }}
     - statefulsetStatus:
         name: {{ .Release.Name }}-nats
         namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
## Summary

Support bundle failed on EC v3 with:

\`\`\`
The deployment "drone-rx-cloudnative-pg" was not found
\`\`\`

## Root cause

The CNPG operator deployment name depends on how the operator was installed:

| Install path | \`cnpgOperator.managed\` | Deployment name |
|---|---|---|
| helm-CLI | true (subchart of drone-rx) | \`drone-rx-cloudnative-pg\` |
| EC / KOTS | false (separate \`cnpg-operator\` HelmChart CR) | \`cnpg-operator-cloudnative-pg\` |

The analyzer hardcoded the helm-CLI name, so EC installs failed the check.

## Fix

Gate the \`deploymentStatus\` block in \`_supportbundle.tpl\` on \`.Values.cnpgOperator.managed\` — render the subchart-deployment check when true, the separately-managed deployment check when false. Both modes now get a working health signal with paths suited to their install layout.

Verified via \`helm template\` in both modes.