### PR TITLE
fix(kots-config): Hide live-tracking when unentitled; drop broken locked placeholder

### DIFF
--- a/replicated/kots-config.yaml
+++ b/replicated/kots-config.yaml
@@ -186,23 +186,16 @@ spec:
           default: "0"
     - name: features
       title: Features
-      description: Entitlement-gated paying features. Locked items are unavailable on your current license — contact your vendor to upgrade.
+      description: Entitlement-gated paying features. Items in this group are only visible when your license includes the corresponding entitlement — contact your vendor to upgrade.
       items:
-        # Live Drone Tracking — editable when the license entitles this feature.
+        # Live Drone Tracking — shown only when the license entitles this feature.
+        # Rubric 4.7 permits "hidden OR locked". We use `when` to hide because KOTS
+        # admin console doesn't visually enforce `readonly: true` (the input renders
+        # editable on both type:bool and type:text, even though the server rejects
+        # saves). Hiding is the only UX-reliable option currently.
         - name: live_tracking_enabled
           title: Live Drone Tracking
           help_text: Stream real-time drone telemetry to the UI.
           type: bool
           default: "1"
           when: 'repl{{ LicenseFieldValue "live_tracking_enabled" | ParseBool }}'
-        # Live Drone Tracking — locked placeholder shown when the license lacks
-        # the entitlement. Uses type=text + readonly so the admin console renders
-        # it as a disabled/greyed field — KOTS bool checkboxes with readonly=true
-        # still render as clickable in the UI (server rejects saves but UX is confusing).
-        - name: live_tracking_enabled_locked
-          title: Live Drone Tracking
-          help_text: Your license does not include the live_tracking_enabled entitlement. Contact your vendor to upgrade.
-          type: text
-          value: "🔒 Locked — license upgrade required"
-          readonly: true
-          when: 'repl{{ not (LicenseFieldValue "live_tracking_enabled" | ParseBool) }}'


### PR DESCRIPTION
## Summary

User report: the "locked" live-tracking placeholder was still rendering as a normal editable text field in the KOTS admin console, with value \`0\` that the user could freely overwrite. Screenshot confirmed.

## Root cause

KOTS admin console **doesn't visually enforce \`readonly: true\`** on either \`type: bool\` or \`type: text\` config items — the input renders as editable even though the server rejects saves. Both our prior attempts (bool-locked, text-locked) failed for this reason.

## Fix

Rubric 4.7 permits "hidden OR locked". Since KOTS doesn't render "locked" cleanly today, switch to **hidden** via \`when: LicenseFieldValue=true\` on the editable item. When the license lacks the entitlement, the live-tracking item is entirely absent from the config screen. Drop the locked placeholder.

Group description reworded to "Items in this group are only visible when your license includes the corresponding entitlement — contact your vendor to upgrade." — so the Features section still communicates that paid features exist, without misleading UI elements.

## Data safety note (already true)

The locked placeholder had a distinct name (\`live_tracking_enabled_locked\`) that the HelmChart CR \`and\`-guard doesn't reference. Whatever a user typed had no functional effect. Still removing it is the right call because (a) UX was bad, (b) the item shouldn't exist at all if we can't make it display correctly.

## Test plan
- [ ] KOTS install with license **lacking** \`live_tracking_enabled\` → the Features group renders with just its title + description, no visible items.
- [ ] KOTS install with license **having** \`live_tracking_enabled=true\` → the editable bool toggle renders; toggling off still and-guards to false in the chart.